### PR TITLE
Fix frontmatter parsing issues by removing blank lines and BOM

### DIFF
--- a/docs/1-neoedge-ng4500-series/2-ng4500-cb01-development-board/2-software-guide/3-software-frameworks-and-tools/1-ollama.md
+++ b/docs/1-neoedge-ng4500-series/2-ng4500-cb01-development-board/2-software-guide/3-software-frameworks-and-tools/1-ollama.md
@@ -1,4 +1,3 @@
-
 ---
 description: 本指南讲解如何在 NVIDIA Jetson Orin 设备上安装、更新、配置和卸载 Ollama。支持本地运行 LLMs 推理，具备 CUDA 加速能力并针对 Jetson 硬件优化。
 keywords: [Ollama, NVIDIA Jetson, Orin Nano, 大语言模型, LLM 推理, CUDA 加速, 边缘 AI, 模型管理]

--- a/docs/4-ai-application/0-cinfer-ai-Inference-service/0-quick-start.md
+++ b/docs/4-ai-application/0-cinfer-ai-Inference-service/0-quick-start.md
@@ -1,5 +1,3 @@
-
-
 ---
 description: Cinfer 快速入门指南。了解如何通过 Docker 部署通用 Vision AI 推理软件，管理 ONNX 模型并集成标准 OpenAPI 服务进行图像识别。
 keywords: [Cinfer, Vision AI, ONNX, Docker 部署, 模型管理, AI 推理, OpenAPI, 快速入门, 计算机视觉, 边缘计算]

--- a/docs/4-ai-application/0-cinfer-ai-Inference-service/1-user-guide.md
+++ b/docs/4-ai-application/0-cinfer-ai-Inference-service/1-user-guide.md
@@ -1,4 +1,3 @@
-
 ---
 description: 学习如何使用 Cinfer 进行 AI 模型管理、Token 授权及标准 API 请求。本文提供完整的软件操作指南，涵盖 Dashboard 监控、模型发布及访问控制。
 keywords: [Cinfer 使用指南, AI 推理服务, 模型管理, Token 授权, OpenAPI, 流程控制, 软件操作, 权限管理, 接口调用]

--- a/docs/4-ai-application/1-ai-box-appliction-expansion/0-fighting-and-Iterative-model-deployment.md
+++ b/docs/4-ai-application/1-ai-box-appliction-expansion/0-fighting-and-Iterative-model-deployment.md
@@ -1,4 +1,3 @@
-
 ---
 description: 本指南介绍如何利用 NeoEdge AI 边缘计算盒（NG4500 系列）部署“打架与跌倒” AI 模型。涵盖系统整体架构、固件安装及 VMS 视频管理系统的配置流程。
 keywords: [AI 边缘计算盒, NG4500, 打架检测, 跌倒检测, VMS 配置, IPC 部署, 行为识别, 边缘 AI 应用, 智能监控, 安全防护]
@@ -20,7 +19,6 @@ tags: [AI应用, 行为分析, 边缘计算, 安全监控, NG4500]
   <img src="https://resources.camthink.ai/wiki/img/ai-application/ai-box-appliction-expansion/fighting-and-Iterative-model-deployment/ipc.png" alt="ipc" style={{ flex: '1 1 280px', maxWidth: '360px', width: '100%', height: 'auto', borderRadius: '6px', background: '#fff', boxShadow: '0 1px 4px rgba(0,0,0,.12)' }} />
   <img src="https://resources.camthink.ai/wiki/img/ai-application/ai-box-appliction-expansion/fighting-and-Iterative-model-deployment/box.png" alt="box" style={{ flex: '1 1 280px', maxWidth: '360px', width: '100%', height: 'auto', borderRadius: '6px', background: '#fff', boxShadow: '0 1px 4px rgba(0,0,0,.12)' }} />
 </div>
-
 
 ## 整体架构
 
@@ -74,7 +72,6 @@ AIBOX 算法固件包下载地址：[msaibox_arm64_1.0.0.1-r1-c1.deb](https://re
 
 输入AI BOX 用户名和密码,是初始化BOX设备时设置的.
 
-
 <div style={{ display: 'flex', flexWrap: 'wrap', gap: '16px', justifyContent: 'center', margin: '8px 0 16px' }}>
   <img src="https://resources.camthink.ai/wiki/img/ai-application/ai-box-appliction-expansion/fighting-and-Iterative-model-deployment/login.png" alt="login" style={{ flex: '1 1 280px', maxWidth: '360px', width: '100%', height: 'auto', borderRadius: '6px', background: '#fff', boxShadow: '0 1px 4px rgba(0,0,0,.12)' }} />
   <img src="https://resources.camthink.ai/wiki/img/ai-application/ai-box-appliction-expansion/fighting-and-Iterative-model-deployment/login2.png" alt="login" style={{ flex: '1 1 280px', maxWidth: '360px', width: '100%', height: 'auto', borderRadius: '6px', background: '#fff', boxShadow: '0 1px 4px rgba(0,0,0,.12)' }} />
@@ -96,7 +93,6 @@ AIBOX 算法固件包下载地址：[msaibox_arm64_1.0.0.1-r1-c1.deb](https://re
   <img src="https://resources.camthink.ai/wiki/img/ai-application/ai-box-appliction-expansion/fighting-and-Iterative-model-deployment/dpkg.png" alt="dpkg" style={{ flex: '1 1 280px', maxWidth: '360px', width: '100%', height: 'auto', borderRadius: '6px', background: '#fff', boxShadow: '0 1px 4px rgba(0,0,0,.12)' }} />
   <img src="https://resources.camthink.ai/wiki/img/ai-application/ai-box-appliction-expansion/fighting-and-Iterative-model-deployment/systemctl.png" alt="systemctl" style={{ flex: '1 1 280px', maxWidth: '360px', width: '100%', height: 'auto', borderRadius: '6px', background: '#fff', boxShadow: '0 1px 4px rgba(0,0,0,.12)' }} />
 </div>
-
 
 ## VMS端应用配置与BOX连接
 
@@ -134,7 +130,6 @@ AIBOX 算法固件包下载地址：[msaibox_arm64_1.0.0.1-r1-c1.deb](https://re
   <img src="https://resources.camthink.ai/wiki/img/ai-application/ai-box-appliction-expansion/fighting-and-Iterative-model-deployment/parameter-configuration.png" alt="vms-install" style={{ maxWidth: '480px', width: '100%', height: 'auto', borderRadius: '6px', boxShadow: '0 1px 4px rgba(0,0,0,.12)' }} />
 </div>
 
-
 ### 步骤四：事件&报警
 
 本步骤用于配置触发算法识别了会执行什么动作、动作执行具体是怎么样的以及执行后的报警显示配置，是基于UI显示上的触发动作。
@@ -167,7 +162,6 @@ AIBOX 算法固件包下载地址：[msaibox_arm64_1.0.0.1-r1-c1.deb](https://re
   <img src="https://resources.camthink.ai/wiki/img/ai-application/ai-box-appliction-expansion/fighting-and-Iterative-model-deployment/ipc-front-end-deployment2.png" alt="ipc-front-end-deployment" style={{ maxWidth: '480px', width: '100%', height: 'auto', borderRadius: '6px', boxShadow: '0 1px 4px rgba(0,0,0,.12)' }} />
 </div>
 
-
 ## 效果展示
 
 **视频1（斗殴检测）：** 展示园区场景中识别斗殴行为、上报告警并联动设备的全流程。
@@ -193,9 +187,6 @@ AIBOX 算法固件包下载地址：[msaibox_arm64_1.0.0.1-r1-c1.deb](https://re
     style={{ maxWidth: '640px', width: '100%', height: '360px', border: 'none', borderRadius: '6px', boxShadow: '0 1px 4px rgba(0,0,0,.12)' }}
   />
 </div>
-
-
-
 
 ## FAQ
 

--- a/docs/5-neoeyes-ne301-series/1-quick-start.md
+++ b/docs/5-neoeyes-ne301-series/1-quick-start.md
@@ -1,4 +1,4 @@
-﻿---
+---
 description: 本教程详细介绍 NeoEyes NE301 快速上手流程，包括设备组装、Web UI 连接与配置、AI 模型部署与调试、MQTT 数据上报设置及硬件参数调整，帮助开发者快速实现边缘 AI 应用落地。
 keywords: [NE301快速开始, NeoEyes教程, AI相机配置, Web UI调试, 模型部署, MQTT配置, 边缘AI入门, 设备组装, 固件升级, 实时推理]
 tags: [快速入门, NE301, 使用教程, AI调试, 配置指南]


### PR DESCRIPTION
Remove blank lines and UTF-8 BOM before frontmatter to ensure Docusaurus correctly parses metadata, preventing descriptions and keywords from rendering as visible content.