### PR TITLE
docs: NE503 Software Guide — System Architecture & Developer Guide

### DIFF
--- a/docs/6-neoeyes-ne503-series/3-software-guide/0-system-architecture.md
+++ b/docs/6-neoeyes-ne503-series/3-software-guide/0-system-architecture.md
@@ -1,0 +1,282 @@
+---
+description: NE503 AIPC 平台架构详解，涵盖四层分层架构、7 个平台服务、HAL v2 硬件抽象、Python SDK、容器安全模型、零拷贝优化及多平台支持，帮助开发者和集成商深入理解系统设计与数据流。
+keywords: [NE503架构, AIPC平台, HAL硬件抽象, 容器隔离, 零拷贝, gRPC, DMA-BUF, 边缘AI, Python SDK, 事件总线]
+tags: [平台架构, NE503, 边缘AI, 开发者文档, 系统设计]
+---
+
+# System Architecture
+
+NE503 AIPC（AI IPC）平台是一个面向边缘 AI 计算的完整软件栈，采用四层分层架构设计，支持多 SoC 平台（Hailo-15 / RKxxx / Jetson）通过硬件抽象层实现平滑迁移。本文档详细介绍平台各层架构、核心服务、数据流和安全模型。
+
+## 1. 四层架构总览
+
+```mermaid
+graph TB
+    subgraph "应用容器层 Application Container"
+        APP["业务服务\nPython / Go / C++"]
+    end
+
+    subgraph "平台服务层 Platform Services"
+        GO["Go 微服务"]
+        CPP["C++ 守护进程"]
+    end
+
+    subgraph "硬件抽象层 HAL"
+        HAL["HAL C API\n动态库加载"]
+    end
+
+    subgraph "硬件层 Hardware"
+        SOC["SoC（当前 Hailo-15H）"]
+    end
+
+    APP -- "SDK gRPC" --> GO
+    APP -- "SDK gRPC + SHM" --> CPP
+    GO -- gRPC --> CPP
+    CPP -- "HAL C API" --> HAL
+    HAL -- 驱动 --> SOC
+```
+
+| 层级 | 职责 | 技术 |
+|:---|:---|:---|
+| 应用容器层 | 第三方 AI 应用、模型推理管线 | Python/Go/C++，容器化运行 |
+| 平台服务层 | 摄像头管理、AI 推理、容器管理、事件分发、设备控制、API 网关、设备发现 | Go 微服务 + C++ 守护进程 |
+| 硬件抽象层 | 统一硬件接口，解耦平台服务与 SoC | C/C++ 函数指针表（Ops），DMA-BUF 零拷贝 |
+| 硬件层 | SoC、NPU、ISP、传感器、MCU | Hailo-15H（当前）、RKxxx / Jetson（可扩展） |
+
+---
+
+## 2. 平台服务层
+
+平台服务层包含多个微服务，通过 gRPC over Unix Domain Socket 进行内部通信。
+
+### 2.1 服务总览
+
+| 服务 | 语言 | 监听地址 | 职责 |
+|:---|:---|:---|:---|
+| **ai-runtime** | C++ | `unix:///run/aipc/ai-runtime.sock` | AI 模型管理与推理调度，NPU 资源分配，GenAI 流式推理 |
+| **app-manager** | Go | `unix:///run/aipc/app-manager.sock` | 容器应用生命周期管理（安装/启动/停止/卸载），基于 containerd |
+| **event-bus** | Go | `unix:///run/aipc/event-bus.sock` + TCP `127.0.0.1:50053` | 发布/订阅消息总线，MQTT 风格通配符匹配 |
+| **device-control** | Go | `unix:///run/aipc/device-control.sock` | 硬件外设控制（灯光/PTZ/镜头/GPIO），MCU UART 通信 |
+| **device-discovery** | Go | `unix:///run/aipc/device-discovery.sock` | 网络设备发现（CT-Disc 协议），设备注册与状态管理 |
+| **platform-api** | Go | `:8080` | HTTP/RESTful API 网关，代理所有后端 gRPC 服务 |
+| **camera-daemon** | C++ | `camera.sock`（FD 发布）+ `camera-control.sock`（gRPC 控制）+ `/run/aipc/shm/`（SHM） | 视频采集、双通道帧分发（FD/SHM）、编码、RTSP 流媒体 |
+
+### 2.2 gRPC API 定义
+
+平台通过 Protocol Buffers 文件定义所有 gRPC 接口：
+
+| Proto 文件 | 服务 | 说明 |
+|:---|:---|:---|
+| `inference.proto` | AI 推理 | 模型注册/推理/流式推理/GenAI 会话管理 |
+| `app.proto` | 容器管理 | 应用安装/生命周期 + 容器/镜像/资源管理 |
+| `event.proto` | 事件总线 | 发布/订阅，MQTT 风格通配符，主题统计 |
+| `device.proto` | 设备控制 | 灯光/PTZ/镜头（含 AF0832）/GPIO/环境/告警/RS485 |
+| `camera.proto` | 摄像头管理 | 视频采集管道、RTSP 流媒体、OSD 叠加 |
+| `lens_hal.proto` | 镜头控制 | `device.proto` 镜头部分的 HAL 桥接实现 |
+| `discovery.proto` | 设备发现 | CT-Disc 协议设备发现、监听与扫描 |
+
+> 各 proto 的完整操作列表见对应的服务参考文档。
+
+---
+
+## 3. 硬件抽象层（HAL）
+
+
+### 3.1 HAL 接口总览
+
+HAL 头文件按组件子目录组织，位于 `hal_v2/include/`：
+
+| 目录 | 覆盖功能 |
+|:---|:---|
+| `media/` | 视频采集、编码（H.264/H.265）、OSD 叠加、ISP、音频、Profile 管理 |
+| `model/` | 模型推理、后处理（NMS）、GenAI（LLM/VLM）、可视化绘制、CLIP 文本编码 |
+| `dsp/` | 裁剪、缩放、格式转换、隐私遮罩、防抖 |
+| `peripheral/` | MCU 通信、GPIO/传感器；设备层含 LED、镜头、告警、RS485、RTC、OTA 等 |
+| `common/` | 公共枚举/错误码、`HalFrameBuffer` 帧缓冲、基础类型、日志 |
+
+> 各服务消费的具体子接口（如 `HalInferenceOps`、`HalPostprocessOps` 等）详见对应的服务参考文档。
+
+### 3.2 核心数据结构：HalFrameBuffer
+
+`HalFrameBuffer` 是平台的核心帧数据载体，用于在视频采集、AI 推理、编码等模块间传递帧数据。
+
+**数据封装：**
+- **图像元数据**：宽高、像素格式、时间戳
+- **内存描述**：DMA-BUF fd、虚拟地址、stride/size
+- **私有数据**：通过 `priv` 指针透传平台特定信息
+
+- **内存模式**：支持 DMA-BUF（零拷贝）和 CPU Memory 两种。视频→AI→编码全链路共享同一 DMA-BUF，无需内存拷贝。
+- **生命周期**：通过引用计数管理（`hal_frame_buffer_ref` / `hal_frame_buffer_release`）。
+
+> 完整结构体定义见 GitHub 仓库 `hal_v2/include/common/` 目录。
+
+### 3.3 多平台支持
+
+```mermaid
+graph LR
+    HAL_API[HAL 统一接口 hal_*.h] --> STUB[Stub 实现 本地测试]
+    HAL_API --> HAILO[Hailo-15 实现 NPU 加速]
+    HAL_API --> RK[RKxxx 实现 Rockchip]
+    HAL_API --> JETSON[Jetson 实现 NVIDIA]
+```
+
+当前实现：Hailo-15（完整）+ Stub（完整桩实现，无硬件开发用）。RKxxx 和 Jetson 可通过实现对应的 HAL 接口扩展支持。
+
+---
+
+## 4. Web 控制台
+
+Web 控制台基于 React 19 + TypeScript + Vite 构建，提供设备管理、视频监控、AI 模型管理、应用管理、系统监控等功能。
+
+| 技术栈 | 组件 |
+|:---|:---|
+| 框架 | React 19 + TypeScript |
+| 构建 | Vite |
+| 状态管理 | Zustand |
+| 数据获取 | TanStack Query |
+| UI 组件 | shadcn/ui + Radix |
+| 测试 | Vitest |
+
+Web 控制台通过 REST API 和 WebSocket 与 platform-api 通信，实时推送 AI 推理结果和设备事件。
+
+访问地址：`http://<设备IP>:8080`。
+
+---
+
+## 5. 容器隔离与安全
+
+NE503 采用多层纵深防御架构，核心原则：**最小权限、访问路径收敛、显式授权**。
+
+### 5.1 安全分层模型
+
+```
+┌──────────────────────────────────────────────┐
+│          应用容器层                            │
+│   Namespaces / Seccomp / Capabilities        │
+│   Cgroup / ReadOnly Rootfs                   │
+└────────────────┬─────────────────────────────┘
+                  │ gRPC over Unix Socket（组权限控制）
+┌────────────────┴─────────────────────────────┐
+│          平台服务层                            │
+│   认证 / 权限收敛 / 审计日志                   │
+└────────────────┬─────────────────────────────┘
+                  │ HAL C API
+┌────────────────┴─────────────────────────────┐
+│          硬件层                                │
+│   TrustZone / Secure Boot                     │
+└──────────────────────────────────────────────┘
+```
+
+### 5.2 容器隔离机制
+
+应用容器通过 Linux 内核机制实现多层隔离：
+
+| 隔离层 | 机制 | 说明 |
+|:---|:---|:---|
+| 进程隔离 | Namespaces | PID / NET / IPC / UTS / MOUNT 等命名空间隔离 |
+| 系统调用过滤 | Seccomp BPF | 白名单模式，仅允许安全系统调用 |
+| 能力裁剪 | Capabilities | 移除危险能力（如 `CAP_SYS_ADMIN`） |
+| 资源限制 | Cgroups | CPU、内存、进程数限制 |
+| 文件系统 | ReadOnly Rootfs | 只读根文件系统 + No New Privileges |
+
+### 5.3 访问路径收敛
+
+所有资源访问必须经过平台服务，容器无法直接访问硬件。Unix Socket 权限通过 Linux 组（AIPC group GID）控制，仅在容器启动时自动注入 Main 容器，Sub 容器无法访问任何 Socket。
+
+### 5.4 声明式权限模型
+
+应用通过 `app.yaml` 的 `permissions` 字段声明式声明所需权限（视频流、推理模型、事件主题、设备控制、网络出站等），未声明的权限默认不可访问。详见 [应用开发参考](../4-application-guide/1-app-development/1-app-reference.md)。
+
+### 5.5 网络安全
+
+| 模式 | 说明 |
+|:---|:---|
+| **Isolated（默认）** | 无网络访问，仅通过 SDK 与平台服务通信 |
+| **Bridge（仅多容器）** | 通过 `aipc-br0` 网桥，出站白名单控制 |
+| **Host** | 共享宿主机网络栈 |
+
+Platform API 支持可选的 Bearer Token（JWT）认证，公开端点仅 `/api/login` 和 `/api/v1/system/health`。
+
+### 5.6 多容器安全边界
+
+| 角色 | 权限 |
+|:---|:---|
+| **Main 容器** | 获得平台 Socket 访问权限，可调用 AI 推理、事件总线等 |
+| **Sub 容器** | 完全隔离，仅通过共享网络命名空间与 Main 容器内部通信 |
+
+---
+
+## 6. 关键技术特性
+
+### 6.1 零拷贝优化
+
+```mermaid
+sequenceDiagram
+    participant S as 传感器
+    participant D as DMA-BUF
+    participant V as Video 模块
+    participant A as AI Runtime
+    participant C as Codec
+
+    S->>D: 采集原始数据，创建 DMA-BUF
+    D->>V: 共享 DMA-BUF（无内存拷贝）
+    V->>A: 路由至推理模块（零拷贝访问）
+    A->>A: 执行 AI 推理
+    D->>C: 同一 DMA-BUF 路由至编码模块
+    Note over D,C: DMA-BUF 生命周期由引用计数管理
+```
+
+核心机制：
+- `HalFrameBuffer` 通过 `dma_fds[]` 传递 DMA-BUF 文件描述符，视频→AI→编码全程零拷贝
+- 引用计数管理帧生命周期（`hal_frame_buffer_ref` / `hal_frame_buffer_release`）
+- AI Runtime 与 Camera Daemon 之间通过 `SCM_RIGHTS` 传递 FD（无需内存拷贝）
+
+### 6.2 事件驱动架构
+
+Event Bus 采用发布/订阅模式，支持 MQTT 风格通配符匹配：
+
+| 模式 | 说明 | 示例 |
+|:---|:---|:---|
+| 精确匹配 | 完全匹配主题名 | `app/myapp/status` |
+| ``*`` 单级通配 | 匹配一个层级 | `app/*/status` |
+| ``**`` 多级通配 | 匹配多个层级 | `model/**/detections` |
+
+所有服务产生的推理结果、容器事件、设备事件均通过 Event Bus 分发，第三方应用通过 SDK 的 `EventClient` 订阅感兴趣的主题。
+
+### 6.3 容器化应用平台
+
+- 基于 containerd 运行时，OCI 标准镜像部署
+- 多容器支持（Main + Sub），插件化依赖解析
+- 健康检查系统（Command / HTTP / TCP，指数退避策略）
+- 自动重启（故障时 backoff 策略）
+
+---
+
+## 7. 系统配置
+
+平台使用 YAML 配置文件管理所有服务参数，配置文件位于 `configs/` 目录：
+
+| 配置文件 | 服务 | 核心配置项 |
+|:---|:---|:---|
+| `platform-api.yaml` | platform-api | 服务器端口、认证密钥、日志级别 |
+| `platform/app-manager.yaml` | app-manager | containerd 连接、安全策略、资源限制 |
+| `platform/event-bus.yaml` | event-bus | Socket 路径、TCP 监听、主题 ACL |
+| `platform/device-control.yaml` | device-control | MCU UART 设备、镜头参数、自动化规则 |
+| `platform/camera-daemon.yaml` | camera-daemon | 视频采集、编码参数、RTSP 配置 |
+| `platform/discovery.yaml` | device-discovery | CT-Disc 协议参数 |
+| `ai/ai-runtime.yaml` | ai-runtime | HAL 库路径、模型仓库、调度器、自动推理管道 |
+| `preload.yaml` | pack-factory | 工厂预装（预装模型与应用） |
+| `security/seccomp-default.json` | 安全 | 默认 Seccomp 系统调用白名单 |
+
+安装位置：`/opt/aipc/`（二进制 `bin/`、配置 `etc/`）。
+
+---
+
+## 8. 相关文档
+
+- [应用开发指南](../4-application-guide/1-app-development/1-app-reference.md) — 如何编写和部署容器应用
+- [Python SDK 参考](../4-application-guide/1-app-development/2-sdk-reference.md) — SDK API 签名与使用示例
+- [RESTful API 参考](../4-application-guide/2-3rd-party-integration/0-restful-api.md) — HTTP API 端点完整参考
+- [AI 推理服务](./4-reference/service-reference/0-ai-runtime.md) — AI Runtime 深度解析
+- [容器应用管理](./4-reference/service-reference/1-app-manager.md) — App Manager 深度解析
+- [配置文件参考](./4-reference/1-config-reference.md) — 所有配置文件详细参数

--- a/docs/6-neoeyes-ne503-series/3-software-guide/0-system-architecture.md
+++ b/docs/6-neoeyes-ne503-series/3-software-guide/0-system-architecture.md
@@ -59,7 +59,7 @@ graph TB
 | **device-control** | Go | `unix:///run/aipc/device-control.sock` | 硬件外设控制（灯光/PTZ/镜头/GPIO），MCU UART 通信 |
 | **device-discovery** | Go | `unix:///run/aipc/device-discovery.sock` | 网络设备发现（CT-Disc 协议），设备注册与状态管理 |
 | **platform-api** | Go | `:8080` | HTTP/RESTful API 网关，代理所有后端 gRPC 服务 |
-| **camera-daemon** | C++ | `camera.sock`（FD 发布）+ `camera-control.sock`（gRPC 控制）+ `/run/aipc/shm/`（SHM） | 视频采集、双通道帧分发（FD/SHM）、编码、RTSP 流媒体 |
+| **camera-daemon** | C++ | `unix:///run/aipc/camera.sock`（FD 发布）+ `unix:///run/aipc/camera-control.sock`（gRPC 控制）+ `/run/aipc/shm/`（SHM） | 视频采集、双通道帧分发（FD/SHM）、编码、RTSP 流媒体 |
 
 ### 2.2 gRPC API 定义
 

--- a/docs/6-neoeyes-ne503-series/3-software-guide/1-developer-guide.md
+++ b/docs/6-neoeyes-ne503-series/3-software-guide/1-developer-guide.md
@@ -1,0 +1,454 @@
+---
+description: NE503 AIPC 平台开发者指南，涵盖环境搭建、分层构建和常见构建问题。
+keywords: [NE503, 开发环境, 构建, Docker, Hailo SDK, 交叉编译]
+tags: [平台开发, NE503, 环境搭建, 构建]
+---
+
+# Developer Guide
+
+本文档指导你搭建 NE503 AIPC 平台的完整开发环境，并完成从源码到发布包的构建。
+
+## Part A：环境搭建
+
+### 1. 系统要求
+
+| 系统 | 支持程度 | 说明 |
+|------|---------|------|
+| Ubuntu 20.04+ | 完全支持 | 推荐，所有层级原生可用 |
+| macOS (Intel / Apple Silicon) | 支持 | Layer 1/2 原生可用；Layer 3 经 Docker 镜像（arm64 原生，无需 QEMU） |
+
+**硬件：** 最低 4 核 CPU、8 GB 内存、20 GB 磁盘。仅 Go/Web 开发时 4 GB 内存即可。
+
+### 2. 获取源码
+
+```bash
+git clone <repo-url> && cd ne503
+```
+
+验证仓库完整性：
+
+```bash
+ls Makefile platform/ web/
+```
+
+项目根目录结构：
+
+```
+ne503/
+├── platform/      # 平台服务（Go + C++）
+├── hal/           # HAL v1（C，legacy）
+├── hal_v2/        # HAL v2（C++，推荐）
+├── sdk/           # 开发者 SDK（Python / Go）
+├── web/           # Web 控制台（React + TypeScript）
+├── apps/          # 示例应用
+├── configs/       # 配置模板
+├── tools/         # 开发工具
+├── scripts/       # 构建/测试/部署脚本
+└── docker/        # Docker 开发环境
+```
+
+### 3. 安装依赖
+
+NE503 构建系统分为三层：
+
+| 层级 | 内容 | 典型场景 |
+|------|------|---------|
+| Layer 1 | Go + Node.js + protoc + Python | 平台服务、Web 控制台、SDK 开发 |
+| Layer 2 | Layer 1 + CMake + g++ + gRPC C++ | camera-daemon 等原生 C/C++ 组件 |
+| Layer 3 | Layer 1/2 + Hailo Yocto SDK（交叉编译） | Hailo-15 HAL 固件构建 |
+
+大多数开发者只需 Layer 1/2。
+
+**完整发布包构建（`pack-release`）必须安装 Layer 3**；仅开发 Go 服务、Web 控制台或 Python SDK 时可跳过。
+
+**如何选择安装方式：**
+
+| 你的情况 | 选择 |
+|---------|------|
+| 想最快出包 / 不想折腾本机环境 / macOS 用户 | 方式一 Docker（推荐） |
+| Ubuntu 本机开发，能联网跑脚本 | 方式二 脚本安装 |
+| 脚本失败 / 离线 / 需精确控制版本 | 方式三 手动安装 |
+
+> 方式二是方式三的自动化封装——脚本失败时可退回方式三，对照手动步骤排查。
+
+#### 方式一：Docker 预打包镜像（推荐）
+
+预打包镜像已包含三层全部依赖，开箱即用。
+
+镜像为**多平台**（amd64 + arm64），在 Apple Silicon 上自动拉取 arm64 原生版，无需 QEMU 模拟，性能与 Linux 原生一致。
+
+**拉取镜像：**
+
+```bash
+docker pull zerobot/ne503-dev-env-full
+```
+
+**创建持久开发容器：**
+
+```bash
+docker run -d --name ne503-dev \
+  -v $(pwd):/ne503 \
+  -w /ne503 \
+  zerobot/ne503-dev-env-full \
+  bash -c "sleep infinity"
+```
+
+该容器可长期保留、反复使用，无需每次重新创建。后续通过 `docker exec` 使用：
+
+```bash
+docker exec -it ne503-dev bash         # 进入容器交互
+docker exec ne503-dev make env-check   # 在容器内执行命令
+```
+
+容器内三层依赖已预装，跳到 [§4 验证环境](#4-验证环境) 确认即可。
+
+#### 方式二：脚本安装
+
+项目提供自动化脚本，支持 Ubuntu/Debian（apt）和 macOS（brew），覆盖 Layer 1/2：
+
+```bash
+./scripts/setup_env.sh layer1    # Go + Node.js + protoc + Python
+./scripts/setup_env.sh layer2    # Layer 1 + cmake + g++ + gRPC C++
+```
+
+脚本自动检测已有工具并跳过。首次搭建建议直接运行 `./scripts/setup_env.sh layer2`。
+
+脚本也提供 `layer3` 入口，但**不会自动下载 Hailo SDK**（SDK 为约 2.7 GB 的私有工具链，需联系技术支持获取）——它只打印 SDK 的手动安装指引：
+
+```bash
+./scripts/setup_env.sh layer3    # 安装 Layer 2 + 打印 Hailo SDK 手动安装步骤
+```
+
+如需完整构建，推荐方式一 Docker 镜像（SDK 已内置）；或按 `layer3` 打印的指引手动安装 SDK，详见方式三。
+
+安装完成后，**确保 `$(go env GOPATH)/bin` 在 PATH 中**（脚本不会自动配置）：
+
+```bash
+# macOS
+echo 'export PATH="$PATH:$(go env GOPATH)/bin"' >> ~/.zshrc && source ~/.zshrc
+
+# Ubuntu
+echo 'export PATH="$PATH:$(go env GOPATH)/bin"' >> ~/.bashrc && source ~/.bashrc
+```
+
+#### 方式三：手动安装
+
+<details>
+<summary>Ubuntu 20.04+</summary>
+
+**Layer 1：**
+
+```bash
+# Go 1.25+
+sudo add-apt-repository -y ppa:longsleep/golang-backports
+sudo apt-get update -qq && sudo apt-get install -y golang-go
+
+# Node.js 20+
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs && npm install -g pnpm
+
+# protoc + Go 插件
+sudo apt-get install -y protobuf-compiler
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+
+# Python 3
+sudo apt-get install -y python3 python3-pip
+```
+
+**Layer 2（在 Layer 1 基础上追加）：**
+
+```bash
+sudo apt-get install -y build-essential cmake protobuf-compiler-grpc libgrpc++-dev libprotobuf-dev
+```
+
+**Layer 3 — Hailo SDK：**
+
+Hailo Yocto Poky SDK 是 x86_64 Linux 专用交叉编译工具链，用于构建 camera-daemon、ai-runtime 和 HAL v2 固件。
+
+1. 联系 [CamThink 技术支持](mailto:support@camthink.ai) 获取 SDK 安装脚本（文件名格式 `poky-glibc-x86_64-*-aarch64-toolchain-4.0.23.sh`，约 2.7 GB）
+
+2. 安装到 `/opt/poky`：
+
+```bash
+chmod +x poky-glibc-x86_64-*-aarch64-toolchain-4.0.23.sh
+sudo ./poky-glibc-x86_64-*-aarch64-toolchain-4.0.23.sh -d /opt/poky/4.0.23 -y
+```
+
+3. 验证安装：
+
+```bash
+ls /opt/poky/4.0.23/environment-setup-armv8a-poky-linux
+```
+
+> 手动安装的 SDK 路径为 `/opt/poky/4.0.23`。后续章节命令以 Docker 默认的 `/opt/hailo-sdk` 为例——手动安装者请将其替换为 `/opt/poky/4.0.23`。
+
+</details>
+
+<details>
+<summary>macOS</summary>
+
+**Layer 1：**
+
+```bash
+brew install go node protobuf
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+npm install -g pnpm
+```
+
+**Layer 2（在 Layer 1 基础上追加）：**
+
+```bash
+brew install cmake grpc
+xcode-select --install
+```
+
+**Layer 3 — Hailo SDK（仅 Linux）：**
+
+macOS 无法本机安装 Hailo SDK（x86_64 Linux 专用交叉编译工具链）。**Layer 3 请直接使用 [方式一 Docker 预打包镜像](#方式一docker-预打包镜像推荐)**——镜像为多平台（amd64 + arm64），Apple Silicon 拉取 arm64 原生版，Go/Node/CMake/SDK 交叉编译器全部原生可用，容器内三层全通，无需任何手动 SDK 配置。
+
+</details>
+
+#### 依赖版本一览
+
+| 工具 | 最低版本 | 检查命令 | 层级 |
+|------|---------|---------|------|
+| Go | 1.25+ | `go version` | L1 |
+| Node.js | 20+ | `node --version` | L1 |
+| pnpm | 最新 | `pnpm --version` | L1 |
+| protoc | 3.12+ | `protoc --version` | L1 |
+| protoc-gen-go | 最新 | `which protoc-gen-go` | L1 |
+| protoc-gen-go-grpc | 最新 | `which protoc-gen-go-grpc` | L1 |
+| Python | 3.8+ | `python3 --version` | L1 |
+| CMake | 3.16+ | `cmake --version` | L2 |
+| GCC/G++ | 10+ (C++20) | `g++ --version` | L2 |
+| gRPC C++ | 1.30+ | `which grpc_cpp_plugin` | L2 |
+
+### 4. 验证环境
+
+```bash
+make env-check
+```
+
+该命令逐项检查三层依赖并报告状态。三层全通时的输出：
+
+```plaintext
+=== NE503 Build Environment ===
+
+--- Layer 1 (Universal) ---
+  OK: go version go1.25.x linux/arm64
+  OK: libprotoc 3.x.x
+  OK: protoc-gen-go
+  OK: protoc-gen-go-grpc
+  OK: Node.js v20.x.x
+  OK: Python 3.x.x
+  OK: pnpm x.x.x
+
+--- Layer 2 (Native C/C++) ---
+  OK: cmake version 3.x.x
+  OK: g++ (Ubuntu 13.x / Apple clang) x.x.x
+  OK: grpc_cpp_plugin
+
+--- Layer 3 (Hailo-15 Cross-compile) ---
+  OK: Hailo SDK (/opt/hailo-sdk)
+```
+
+> 以上为 Docker 预打包镜像（方式一）的输出。手动安装（方式三）下，Layer 3 显示 `OK: Hailo SDK (/opt/poky/4.0.23)`，两种路径均正常。
+
+如果 Layer 3 未安装，会显示：
+
+```plaintext
+--- Layer 3 (Hailo-15 Cross-compile) ---
+  NOT FOUND: Hailo SDK
+```
+
+Layer 3 缺失仅影响完整发布包构建（`pack-release`），不影响 Go 服务和 Web 控制台开发。
+
+> 如果出现 `WARNING: hailo15 target requested`，说明项目根目录存在 `Makefile.docker`（Docker 容器自动生成的）。删除即可：`rm Makefile.docker`。
+
+### 5. Python SDK 与 IDE 配置
+
+> 以下命令在开发环境内执行：Docker 用户先 `docker exec -it ne503-dev bash` 进入容器，本机用户在项目根目录执行。
+
+#### Python SDK（开发模式）
+
+```bash
+cd sdk/python
+pip3 install -e ".[dev]"
+```
+
+> 报错 `error: externally-managed-environment`（Ubuntu 24.04+、macOS Homebrew Python）时改用 venv：
+>
+> ```bash
+> cd sdk/python
+> python3 -m venv .venv && source .venv/bin/activate
+> pip install -e ".[dev]"
+> ```
+>
+> 安装完成后用 `deactivate` 退出；后续每次开发前 `source .venv/bin/activate` 重新激活即可。
+
+#### IDE 推荐
+
+VS Code + 扩展：
+
+- Go — `golang.go`
+- Python — `ms-python.python`
+- C/C++ — `ms-vscode.cpptools`
+- CMake Tools — `ms-vscode.cmake-tools`
+- Protocol Buffers — `bufbuild.vscode-buf`
+
+## Part B：版本构建
+
+### 6. 完整构建
+
+构建产出 `build/release/aipc-hailo15-<version>.tar.gz` 发布包，包含平台服务、HAL 库、Web 控制台和部署脚本。
+
+#### 容器内构建（推荐，全平台）
+
+使用方式一创建的 `ne503-dev` 容器执行，Ubuntu / macOS Intel / Apple Silicon 通用：
+
+```bash
+docker exec ne503-dev bash -c \
+  'source /opt/hailo-sdk/environment-setup-armv8a-poky-linux && \
+   make pack-release SDK_PATH=/opt/hailo-sdk VERSION=1.0.0'
+```
+
+```plaintext
+# 预期输出（阶段进度，省略单文件编译细节）
+==> Compiling proto (inference / device / event / camera / app / ...)
+==> Building device-control (CGO_ENABLED=0)
+==> Building event-bus / app-manager / platform-api / device-discovery
+==> Building Web Console
+==> Building Python SDK
+=== Layer 1 complete: proto + Go services + web + Python SDK ===
+==> Building HAL v2 [platform=hailo15]
+==> Building camera-daemon / ai-runtime (C++) / aipc-cli
+==> Building tools (shm-reader, nv12-to-jpeg)
+=== Layer 2 complete ===
+==> Packaging release [1.0.0, platform=hailo15]
+=== Release Package Ready ===
+File:   build/release/aipc-hailo15-1.0.0.tar.gz (111M)
+```
+
+> 手动安装环境（方式三）下，SDK 路径为 `/opt/poky/4.0.23`，将上述命令中的 env 脚本和 `SDK_PATH` 替换为该路径即可。
+
+#### 验证构建产物
+
+确认二进制为 ARM aarch64 架构（容器内无 `file` 命令，用 `readelf`）：
+
+```bash
+docker exec ne503-dev bash -c \
+  'readelf -h build/output/device-control | grep Machine'
+# 预期输出: Machine: AArch64
+```
+
+`build/output/` 下所有产物（Go/C++ 服务、`aipc-cli`、`shm-reader`、`hal/hailo15/libaipc_hal.so`）均为 aarch64。在主机（非容器）上也可用 `file build/output/device-control`（输出含 `ARM aarch64`）。
+
+### 7. 单独构建某个服务
+
+开发迭代时只需重编和替换单个服务：
+
+```bash
+# 设备管理
+make device-control HAL_PLATFORM=hailo15
+
+# 消息总线
+make event-bus HAL_PLATFORM=hailo15
+
+# 应用管理
+make app-manager HAL_PLATFORM=hailo15
+
+# API 网关
+make platform-api HAL_PLATFORM=hailo15
+
+# 设备发现
+make device-discovery HAL_PLATFORM=hailo15
+
+# 视频采集（需先 source SDK 环境）
+source /opt/hailo-sdk/environment-setup-armv8a-poky-linux
+make camera-daemon HAL_PLATFORM=hailo15 SDK_PATH=/opt/hailo-sdk
+
+# AI 推理（需先 source SDK 环境）
+source /opt/hailo-sdk/environment-setup-armv8a-poky-linux
+make ai-runtime HAL_PLATFORM=hailo15 SDK_PATH=/opt/hailo-sdk
+```
+
+> `HAL_PLATFORM=hailo15` 自动设置交叉编译参数。以上命令在容器内或已 source SDK 环境的 Linux 上执行；macOS 用户请先 `docker exec -it ne503-dev bash` 进入容器。
+
+### 8. 构建问题排查
+
+#### protoc / protoc-gen-go 未找到
+
+```bash
+sudo apt install protobuf-compiler
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+export PATH="$PATH:$(go env GOPATH)/bin"
+```
+
+#### grpc_cpp_plugin 未找到
+
+```bash
+sudo apt install protobuf-compiler-grpc libgrpc++-dev libprotobuf-dev
+```
+
+#### camera-daemon 交叉编译 protobuf 版本不匹配
+
+C++ proto 文件需用 SDK 自带 protoc 生成。Makefile 在 `HAL_PLATFORM=hailo15` 时自动处理。
+
+如果自动生成失败，可手动运行对应 proto 目标（如 `make proto-camera`），或执行 `make help` 查看 `proto-*` 系列。
+
+#### CMake 选择了错误的工具链
+
+```bash
+rm -rf platform/camera-daemon/build-hailo15
+make camera-daemon HAL_PLATFORM=hailo15 SDK_PATH=/opt/hailo-sdk
+```
+
+#### pnpm 首次运行报 Ignored build scripts
+
+```bash
+cd web && pnpm approve-builds esbuild msw unrs-resolver
+```
+
+#### Web 控制台构建失败（缺少模块）
+
+`pnpm build` 报 `Cannot find module '.../lib/...'`，根因是 `.gitignore` 的 `lib/` 规则误伤了 `web/src/**/lib/` 目录，导致这些源文件没被 git 跟踪。确认 `.gitignore` 包含取消忽略的例外：
+
+```gitignore
+lib/
+!web/src/**/lib/
+```
+
+补上例外后，缺失文件即可正常跟踪，重新拉取后 `pnpm build` 恢复正常。
+
+#### Python SDK 文档构建报 ModuleNotFoundError: grpc
+
+`Building Python SDK Documentation` 阶段刷大量 `ModuleNotFoundError: No module named 'grpc'`，是 sphinx autodoc 导入 SDK 模块时缺 `grpcio` 所致。**非致命**——Python SDK 已构建成功、文档照常生成、构建继续进入 Layer 2，最终出包不受影响，可直接忽略。
+
+### Make 目标速查
+
+| 目标 | 说明 |
+|------|------|
+| `make pack-release` | 完整 Hailo-15 发布（构建 + 打包） |
+| `make pack` | 从已有构建产物打包（无 SDK） |
+| `make platform` | 所有 Go 服务 |
+| `make hal-v2` | HAL v2（`HAL_PLATFORM=hailo15` 交叉编译） |
+| `make camera-daemon` | C++ camera-daemon |
+| `make ai-runtime` | C++ AI 推理服务 |
+| `make proto` | 编译 .proto 生成 Go 代码 |
+| `make web` | Web 控制台（pnpm） |
+| `make layer1` | proto + Go + Web + Python SDK |
+| `make layer2` | Layer 1 + HAL stub + C++ 组件 |
+| `make env-check` | 检查构建依赖 |
+| `make clean` | 清理构建产物 |
+| `make test` | 运行所有测试 |
+
+## 相关文档
+
+- [System Architecture](./0-system-architecture.md) — 四层架构和核心服务详解
+- [System Flashing](./2-system-flashing.md) — 系统镜像烧录和升级
+- [Software Deployment](./3-software-deployment.md) — 平台软件部署和迭代开发
+- [Config Reference](./4-reference/1-config-reference.md) — 服务配置参数
+- [Troubleshooting](./4-reference/0-troubleshooting.md) — 运行时问题排查

--- a/docs/6-neoeyes-ne503-series/3-software-guide/_category_.json
+++ b/docs/6-neoeyes-ne503-series/3-software-guide/_category_.json
@@ -1,0 +1,1 @@
+{"label":"Software Guide","position":3}

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/3-software-guide/0-system-architecture.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/3-software-guide/0-system-architecture.md
@@ -59,7 +59,7 @@ The platform services layer consists of multiple microservices that communicate 
 | **device-control** | Go | `unix:///run/aipc/device-control.sock` | Hardware peripheral control (light/PTZ/lens/GPIO), MCU UART communication |
 | **device-discovery** | Go | `unix:///run/aipc/device-discovery.sock` | Network device discovery (CT-Disc protocol), device registration and state management |
 | **platform-api** | Go | `:8080` | HTTP/RESTful API gateway, proxying all backend gRPC services |
-| **camera-daemon** | C++ | `camera.sock` (FD publish) + `camera-control.sock` (gRPC control) + `/run/aipc/shm/` (SHM) | Video capture, dual-channel frame dispatch (FD/SHM), encoding, RTSP streaming |
+| **camera-daemon** | C++ | `unix:///run/aipc/camera.sock` (FD publish) + `unix:///run/aipc/camera-control.sock` (gRPC control) + `/run/aipc/shm/` (SHM) | Video capture, dual-channel frame dispatch (FD/SHM), encoding, RTSP streaming |
 
 ### 2.2 gRPC API Definitions
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/3-software-guide/0-system-architecture.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/3-software-guide/0-system-architecture.md
@@ -1,0 +1,283 @@
+---
+description: NE503 AIPC platform architecture deep dive, covering the four-layer architecture, 7 platform services, HAL v2 hardware abstraction, Python SDK, container security model, zero-copy optimization, and multi-platform support. Designed to help developers and integrators thoroughly understand system design and data flow.
+keywords: [NE503 architecture, AIPC platform, HAL hardware abstraction, container isolation, zero-copy, gRPC, DMA-BUF, edge AI, Python SDK, event bus]
+tags: [platform architecture, NE503, edge AI, developer documentation, system design]
+---
+
+# System Architecture
+
+The NE503 AIPC (AI IPC) platform is a complete software stack designed for edge AI computing. It adopts a four-layer architecture and supports multiple SoC platforms (Hailo-15 / RKxxx / Jetson) with seamless migration through a hardware abstraction layer. This document provides a detailed overview of each architectural layer, core services, data flow, and the security model.
+
+## 1. Four-Layer Architecture Overview
+
+```mermaid
+graph TB
+    subgraph "Application Container Layer"
+        APP["Business Services\nPython / Go / C++"]
+    end
+
+    subgraph "Platform Services Layer"
+        GO["Go Microservices"]
+        CPP["C++ Daemons"]
+    end
+
+    subgraph "Hardware Abstraction Layer HAL"
+        HAL["HAL C API\nDynamic Library Loading"]
+    end
+
+    subgraph "Hardware Layer"
+        SOC["SoC (Current: Hailo-15H)"]
+    end
+
+    APP -- "SDK gRPC" --> GO
+    APP -- "SDK gRPC + SHM" --> CPP
+    GO -- gRPC --> CPP
+    CPP -- "HAL C API" --> HAL
+    HAL -- Driver --> SOC
+```
+
+| Layer | Responsibility | Technology |
+|:---|:---|:---|
+| Application Container Layer | Third-party AI applications, model inference pipelines | Python/Go/C++, containerized runtime |
+| Platform Services Layer | Camera management, AI inference, container management, event dispatch, device control, API gateway, device discovery | Go microservices + C++ daemons |
+| Hardware Abstraction Layer | Unified hardware interface, decoupling platform services from SoC | C/C++ function pointer tables (Ops), DMA-BUF zero-copy |
+| Hardware Layer | SoC, NPU, ISP, sensors, MCU | Hailo-15H (current), RKxxx / Jetson (extensible) |
+
+---
+
+## 2. Platform Services Layer
+
+The platform services layer consists of multiple microservices that communicate internally via gRPC over Unix Domain Sockets.
+
+### 2.1 Service Overview
+
+| Service | Language | Listen Address | Responsibility |
+|:---|:---|:---|:---|
+| **ai-runtime** | C++ | `unix:///run/aipc/ai-runtime.sock` | AI model management and inference scheduling, NPU resource allocation, GenAI streaming inference |
+| **app-manager** | Go | `unix:///run/aipc/app-manager.sock` | Container application lifecycle management (install/start/stop/uninstall), based on containerd |
+| **event-bus** | Go | `unix:///run/aipc/event-bus.sock` + TCP `127.0.0.1:50053` | Publish/subscribe message bus, MQTT-style wildcard matching |
+| **device-control** | Go | `unix:///run/aipc/device-control.sock` | Hardware peripheral control (light/PTZ/lens/GPIO), MCU UART communication |
+| **device-discovery** | Go | `unix:///run/aipc/device-discovery.sock` | Network device discovery (CT-Disc protocol), device registration and state management |
+| **platform-api** | Go | `:8080` | HTTP/RESTful API gateway, proxying all backend gRPC services |
+| **camera-daemon** | C++ | `camera.sock` (FD publish) + `camera-control.sock` (gRPC control) + `/run/aipc/shm/` (SHM) | Video capture, dual-channel frame dispatch (FD/SHM), encoding, RTSP streaming |
+
+### 2.2 gRPC API Definitions
+
+The platform defines all gRPC interfaces through Protocol Buffers files:
+
+| Proto File | Service | Description |
+|:---|:---|:---|
+| `inference.proto` | AI Inference | Model registration, inference, streaming, GenAI session management |
+| `app.proto` | Container Management | App install/lifecycle + container/image/resource management |
+| `event.proto` | Event Bus | Publish/subscribe, MQTT-style wildcards, topic statistics |
+| `device.proto` | Device Control | Light/PTZ/lens (incl. AF0832)/GPIO/environment/alarm/RS485 |
+| `camera.proto` | Camera Management | Video capture pipeline, RTSP streaming, OSD overlay |
+| `lens_hal.proto` | Lens Control | HAL bridge implementation for the lens portion of `device.proto` |
+| `discovery.proto` | Device Discovery | CT-Disc protocol device discovery, monitoring, and scanning |
+
+> For the complete list of operations per proto, see the corresponding service reference documentation.
+
+---
+
+## 3. Hardware Abstraction Layer (HAL)
+
+
+### 3.1 HAL Interface Overview
+
+HAL headers are organized by component subdirectory under `hal_v2/include/`:
+
+| Directory | Coverage |
+|:---|:---|
+| `media/` | Video capture, encoding (H.264/H.265), OSD, ISP, audio, profile management |
+| `model/` | Model inference, post-processing (NMS), GenAI (LLM/VLM), visualization, CLIP text encoding |
+| `dsp/` | Crop, scale, format conversion, privacy mask, stabilization |
+| `peripheral/` | MCU communication, GPIO/sensor; device layer includes LED, lens, alarm, RS485, RTC, OTA, etc. |
+| `common/` | Common enums/error codes, `HalFrameBuffer` frame buffer, basic types, logging |
+
+> Specific sub-interfaces consumed by each service (e.g., `HalInferenceOps`, `HalPostprocessOps`, etc.) are documented in the corresponding service reference pages.
+
+### 3.2 Core Data Structure: HalFrameBuffer
+
+`HalFrameBuffer` is the platform's core frame data carrier, used to pass frame data between video capture, AI inference, encoding, and other modules.
+
+**Data encapsulation:**
+- **Image metadata**: dimensions, pixel format, timestamp
+- **Memory descriptors**: DMA-BUF fd, virtual addresses, stride/size
+- **Private data**: platform-specific information passed through the `priv` pointer
+
+- **Memory modes**: Supports DMA-BUF (zero-copy) and CPU Memory. The entire video → AI → encoding pipeline shares the same DMA-BUF without memory copying.
+- **Lifecycle**: Managed through reference counting (`hal_frame_buffer_ref` / `hal_frame_buffer_release`).
+
+> For the complete struct definition, see the GitHub repository under `hal_v2/include/common/`.
+
+### 3.3 Multi-Platform Support
+
+```mermaid
+graph LR
+    HAL_API[HAL Unified Interface hal_*.h] --> STUB[Stub Implementation Hardware-free Development]
+    HAL_API --> HAILO[Hailo-15 Implementation NPU Acceleration]
+    HAL_API --> RK[RKxxx Implementation Rockchip]
+    HAL_API --> JETSON[Jetson Implementation NVIDIA]
+```
+
+Current implementations: Hailo-15 (complete) + Stub (complete stub implementation for hardware-free development). RKxxx and Jetson can be supported through the HAL porting guide.
+
+---
+
+## 4. Web Console
+
+The web console is built on React 19 + TypeScript + Vite, providing device management, video monitoring, AI model management, application management, and system monitoring.
+
+| Technology Stack | Component |
+|:---|:---|
+| Framework | React 19 + TypeScript |
+| Build | Vite |
+| State Management | Zustand |
+| Data Fetching | TanStack Query |
+| UI Components | shadcn/ui + Radix |
+| Testing | Vitest |
+
+The web console communicates with platform-api via REST API and WebSocket, receiving real-time AI inference results and device events.
+
+Access URL: `http://<device-ip>:8080`.
+
+---
+
+## 5. Container Isolation and Security
+
+NE503 adopts a multi-layered defense-in-depth architecture. Core principles: **least privilege, access path convergence, and explicit authorization**.
+
+### 5.1 Security Layer Model
+
+```
+┌──────────────────────────────────────────────┐
+│          Application Container Layer          │
+│   Namespaces / Seccomp / Capabilities        │
+│   Cgroup / ReadOnly Rootfs                   │
+└────────────────┬─────────────────────────────┘
+                  │ gRPC over Unix Socket (group permission control)
+┌────────────────┴─────────────────────────────┐
+│          Platform Services Layer              │
+│   Authentication / Permission Convergence    │
+│   Audit Logging                              │
+└────────────────┬─────────────────────────────┘
+                  │ HAL C API
+┌────────────────┴─────────────────────────────┐
+│          Hardware Layer                       │
+│   TrustZone / Secure Boot                    │
+└──────────────────────────────────────────────┘
+```
+
+### 5.2 Container Isolation Mechanisms
+
+Application containers are isolated through multiple Linux kernel mechanisms:
+
+| Isolation Layer | Mechanism | Description |
+|:---|:---|:---|
+| Process isolation | Namespaces | PID / NET / IPC / UTS / MOUNT namespace isolation |
+| Syscall filtering | Seccomp BPF | Allowlist mode, only safe system calls permitted |
+| Capability trimming | Capabilities | Removes dangerous capabilities (e.g., `CAP_SYS_ADMIN`) |
+| Resource limits | Cgroups | CPU, memory, and process count limits |
+| Filesystem | ReadOnly Rootfs | Read-only root filesystem + No New Privileges |
+
+### 5.3 Access Path Convergence
+
+All resource access must go through platform services. Containers cannot access hardware directly. Unix Socket permissions are controlled through Linux groups (AIPC group GID), automatically injected only into the Main container at startup. Sub containers cannot access any sockets.
+
+### 5.4 Declarative Permission Model
+
+Applications declare required permissions (video streams, inference models, event topics, device control, network outbound, etc.) through the `permissions` field in `app.yaml`. Undeclared permissions are inaccessible by default. See [App Development Reference](../4-application-guide/1-app-development/1-app-reference.md) for details.
+
+### 5.5 Network Security
+
+| Mode | Description |
+|:---|:---|
+| **Isolated (default)** | No network access, communicates with platform services only through SDK |
+| **Bridge (multi-container only)** | Connected via `aipc-br0` bridge, outbound allowlist control |
+| **Host** | Shares host network stack |
+
+Platform API supports optional Bearer Token (JWT) authentication. Public endpoints are limited to `/api/login` and `/api/v1/system/health`.
+
+### 5.6 Multi-Container Security Boundary
+
+| Role | Permissions |
+|:---|:---|
+| **Main Container** | Granted platform Socket access, can call AI inference, event bus, etc. |
+| **Sub Container** | Fully isolated, communicates with Main container only through shared network namespace |
+
+---
+
+## 6. Key Technical Features
+
+### 6.1 Zero-Copy Optimization
+
+```mermaid
+sequenceDiagram
+    participant S as Sensor
+    participant D as DMA-BUF
+    participant V as Video Module
+    participant A as AI Runtime
+    participant C as Codec
+
+    S->>D: Capture raw data, create DMA-BUF
+    D->>V: Share DMA-BUF (no memory copy)
+    V->>A: Route to inference module (zero-copy access)
+    A->>A: Execute AI inference
+    D->>C: Route same DMA-BUF to encoding module
+    Note over D,C: DMA-BUF lifecycle managed by reference counting
+```
+
+Core mechanisms:
+- `HalFrameBuffer` passes DMA-BUF file descriptors via `dma_fds[]`, enabling zero-copy throughout the video -> AI -> encoding pipeline
+- Reference counting manages frame lifecycle (`hal_frame_buffer_ref` / `hal_frame_buffer_release`)
+- FD passing between AI Runtime and Camera Daemon via `SCM_RIGHTS` (no memory copy required)
+
+### 6.2 Event-Driven Architecture
+
+The Event Bus uses a publish/subscribe pattern with MQTT-style wildcard matching:
+
+| Pattern | Description | Example |
+|:---|:---|:---|
+| Exact match | Exact topic name match | `app/myapp/status` |
+| ``*`` Single-level wildcard | Matches one level | `app/*/status` |
+| ``**`` Multi-level wildcard | Matches multiple levels | `model/**/detections` |
+
+All inference results, container events, and device events generated by services are dispatched through the Event Bus. Third-party applications subscribe to topics of interest using the SDK's `EventClient`.
+
+### 6.3 Containerized Application Platform
+
+- Based on containerd runtime, OCI standard image deployment
+- Multi-container support (Main + Sub), plugin-based dependency resolution
+- Health check system (Command / HTTP / TCP, exponential backoff strategy)
+- Automatic restart (backoff strategy on failure)
+
+---
+
+## 7. System Configuration
+
+The platform uses YAML configuration files to manage all service parameters. Configuration files are located in the `configs/` directory:
+
+| Configuration File | Service | Core Configuration |
+|:---|:---|:---|
+| `platform-api.yaml` | platform-api | Server port, authentication keys, log level |
+| `platform/app-manager.yaml` | app-manager | containerd connection, security policies, resource limits |
+| `platform/event-bus.yaml` | event-bus | Socket path, TCP listener, topic ACL |
+| `platform/device-control.yaml` | device-control | MCU UART device, lens parameters, automation rules |
+| `platform/camera-daemon.yaml` | camera-daemon | Video capture, encoding parameters, RTSP configuration |
+| `platform/discovery.yaml` | device-discovery | CT-Disc protocol parameters |
+| `ai/ai-runtime.yaml` | ai-runtime | HAL library paths, model repository, scheduler, auto-inference pipeline |
+| `preload.yaml` | pack-factory | Factory preloading (pre-installed models and applications) |
+| `security/seccomp-default.json` | Security | Default Seccomp system call allowlist |
+
+Installation path: `/opt/aipc/` (binaries in `bin/`, configuration in `etc/`).
+
+---
+
+## 8. Related Documentation
+
+- [Application Development Guide](../4-application-guide/1-app-development/1-app-reference.md) — How to write and deploy container applications
+- [Python SDK Reference](../4-application-guide/1-app-development/2-sdk-reference.md) — SDK API signatures and usage examples
+- [RESTful API Reference](../4-application-guide/2-3rd-party-integration/0-restful-api.md) — Complete HTTP API endpoint reference
+- [AI Inference Service](./4-reference/service-reference/0-ai-runtime.md) — AI Runtime deep dive
+- [Container Application Management](./4-reference/service-reference/1-app-manager.md) — App Manager deep dive
+- [Configuration File Reference](./4-reference/1-config-reference.md) — Detailed parameters for all configuration files

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/3-software-guide/1-developer-guide.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/3-software-guide/1-developer-guide.md
@@ -1,0 +1,454 @@
+---
+description: NE503 AIPC platform developer guide covering environment setup, layered builds, and common build issues.
+keywords: [NE503, development environment, build, Docker, Hailo SDK, cross-compile]
+tags: [platform development, NE503, environment setup, build]
+---
+
+# Developer Guide
+
+This document guides you through setting up the complete NE503 AIPC development environment and building from source to release package.
+
+## Part A: Environment Setup
+
+### 1. System Requirements
+
+| System | Support Level | Notes |
+|--------|--------------|--------|
+| Ubuntu 20.04+ | Full support | Recommended, all layers available natively |
+| macOS (Intel / Apple Silicon) | Supported | Layer 1/2 native; Layer 3 via Docker image (arm64 native, no QEMU) |
+
+**Hardware:** Minimum 4-core CPU, 8 GB RAM, 20 GB disk. 4 GB RAM sufficient for Go/Web-only development.
+
+### 2. Get Source Code
+
+```bash
+git clone <repo-url> && cd ne503
+```
+
+Verify repository integrity:
+
+```bash
+ls Makefile platform/ web/
+```
+
+Project root structure:
+
+```
+ne503/
+├── platform/      # Platform services (Go + C++)
+├── hal/           # HAL v1 (C, legacy)
+├── hal_v2/        # HAL v2 (C++, recommended)
+├── sdk/           # Developer SDK (Python / Go)
+├── web/           # Web console (React + TypeScript)
+├── apps/          # Example applications
+├── configs/       # Configuration templates
+├── tools/         # Development tools
+├── scripts/       # Build/test/deploy scripts
+└── docker/        # Docker development environment
+```
+
+### 3. Install Dependencies
+
+The NE503 build system has three layers:
+
+| Layer | Contents | Typical Use Case |
+|-------|----------|-----------------|
+| Layer 1 | Go + Node.js + protoc + Python | Platform services, Web console, SDK development |
+| Layer 2 | Layer 1 + CMake + g++ + gRPC C++ | Native C/C++ components like camera-daemon |
+| Layer 3 | Layer 1/2 + Hailo Yocto SDK (cross-compile) | Hailo-15 HAL firmware builds |
+
+Most developers only need Layer 1/2.
+
+**A full release build (`pack-release`) requires Layer 3**; it can be skipped only when developing Go services, the Web console, or the Python SDK.
+
+**Which option to choose:**
+
+| Your situation | Choose |
+|----------------|--------|
+| Want to ship a release fastest / no local setup / on macOS | Option A Docker (recommended) |
+| Ubuntu native development, can run scripts online | Option B Script install |
+| Script failed / offline / need precise version control | Option C Manual install |
+
+> Option B is the automated wrapper of Option C — if the script fails, fall back to Option C and follow the manual steps to debug.
+
+#### Option A: Docker Pre-built Image (Recommended)
+
+The pre-built image includes all three layers of dependencies, ready to use out of the box.
+
+The image is **multi-platform** (amd64 + arm64); on Apple Silicon it pulls the arm64 native variant automatically — no QEMU emulation, with performance on par with native Linux.
+
+**Pull the image:**
+
+```bash
+docker pull zerobot/ne503-dev-env-full
+```
+
+**Create a persistent dev container:**
+
+```bash
+docker run -d --name ne503-dev \
+  -v $(pwd):/ne503 \
+  -w /ne503 \
+  zerobot/ne503-dev-env-full \
+  bash -c "sleep infinity"
+```
+
+The container is reusable and long-lived — no need to recreate it each time. Use `docker exec` for daily work:
+
+```bash
+docker exec -it ne503-dev bash         # Enter container interactively
+docker exec ne503-dev make env-check   # Run commands inside the container
+```
+
+All three layers are pre-installed. Skip to [§4 Verify Environment](#4-verify-environment) to confirm.
+
+#### Option B: Script Install
+
+The project provides automated scripts supporting Ubuntu/Debian (apt) and macOS (brew), covering Layer 1/2:
+
+```bash
+./scripts/setup_env.sh layer1    # Go + Node.js + protoc + Python
+./scripts/setup_env.sh layer2    # Layer 1 + cmake + g++ + gRPC C++
+```
+
+Scripts automatically detect and skip existing tools. For first-time setup, run `./scripts/setup_env.sh layer2` directly.
+
+The script also offers a `layer3` entry point, but it **does not auto-download the Hailo SDK** (the SDK is a ~2.7 GB private toolchain, obtainable from technical support) — it only prints the manual SDK installation steps:
+
+```bash
+./scripts/setup_env.sh layer3    # installs Layer 2 + prints Hailo SDK manual install steps
+```
+
+For full builds, Option A (Docker image, SDK built in) is recommended; or follow the steps printed by `layer3` to install the SDK manually (see Option C).
+
+After installation, **ensure `$(go env GOPATH)/bin` is in your PATH** (scripts do not configure this automatically):
+
+```bash
+# macOS
+echo 'export PATH="$PATH:$(go env GOPATH)/bin"' >> ~/.zshrc && source ~/.zshrc
+
+# Ubuntu
+echo 'export PATH="$PATH:$(go env GOPATH)/bin"' >> ~/.bashrc && source ~/.bashrc
+```
+
+#### Option C: Manual Install
+
+<details>
+<summary>Ubuntu 20.04+</summary>
+
+**Layer 1:**
+
+```bash
+# Go 1.25+
+sudo add-apt-repository -y ppa:longsleep/golang-backports
+sudo apt-get update -qq && sudo apt-get install -y golang-go
+
+# Node.js 20+
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs && npm install -g pnpm
+
+# protoc + Go plugins
+sudo apt-get install -y protobuf-compiler
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+
+# Python 3
+sudo apt-get install -y python3 python3-pip
+```
+
+**Layer 2 (in addition to Layer 1):**
+
+```bash
+sudo apt-get install -y build-essential cmake protobuf-compiler-grpc libgrpc++-dev libprotobuf-dev
+```
+
+**Layer 3 — Hailo SDK:**
+
+The Hailo Yocto Poky SDK is an x86_64 Linux-only cross-compile toolchain for building camera-daemon, ai-runtime, and HAL v2 firmware.
+
+1. Contact [CamThink Technical Support](mailto:support@camthink.ai) for the SDK installer (filename format: `poky-glibc-x86_64-*-aarch64-toolchain-4.0.23.sh`, approximately 2.7 GB)
+
+2. Install to `/opt/poky`:
+
+```bash
+chmod +x poky-glibc-x86_64-*-aarch64-toolchain-4.0.23.sh
+sudo ./poky-glibc-x86_64-*-aarch64-toolchain-4.0.23.sh -d /opt/poky/4.0.23 -y
+```
+
+3. Verify installation:
+
+```bash
+ls /opt/poky/4.0.23/environment-setup-armv8a-poky-linux
+```
+
+> A manual install places the SDK at `/opt/poky/4.0.23`. Commands in later sections use the Docker default `/opt/hailo-sdk` — manual-install users should substitute `/opt/poky/4.0.23`.
+
+</details>
+
+<details>
+<summary>macOS</summary>
+
+**Layer 1:**
+
+```bash
+brew install go node protobuf
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+npm install -g pnpm
+```
+
+**Layer 2 (in addition to Layer 1):**
+
+```bash
+brew install cmake grpc
+xcode-select --install
+```
+
+**Layer 3 — Hailo SDK (Linux only):**
+
+macOS cannot install the Hailo SDK natively (it is an x86_64 Linux-only cross-compile toolchain). **For Layer 3, use the [Option A: Docker pre-built image](#option-a-docker-pre-built-image-recommended)** — the image is multi-platform (amd64 + arm64), Apple Silicon pulls the arm64 native variant, so Go / Node / CMake / the SDK cross-compiler all run natively; all three layers are available inside the container, with no manual SDK configuration required.
+
+</details>
+
+#### Dependency Versions
+
+| Tool | Minimum Version | Check Command | Layer |
+|------|----------------|---------------|-------|
+| Go | 1.25+ | `go version` | L1 |
+| Node.js | 20+ | `node --version` | L1 |
+| pnpm | Latest | `pnpm --version` | L1 |
+| protoc | 3.12+ | `protoc --version` | L1 |
+| protoc-gen-go | Latest | `which protoc-gen-go` | L1 |
+| protoc-gen-go-grpc | Latest | `which protoc-gen-go-grpc` | L1 |
+| Python | 3.8+ | `python3 --version` | L1 |
+| CMake | 3.16+ | `cmake --version` | L2 |
+| GCC/G++ | 10+ (C++20) | `g++ --version` | L2 |
+| gRPC C++ | 1.30+ | `which grpc_cpp_plugin` | L2 |
+
+### 4. Verify Environment
+
+```bash
+make env-check
+```
+
+This command checks all three layers and reports status. Output when all three layers pass:
+
+```plaintext
+=== NE503 Build Environment ===
+
+--- Layer 1 (Universal) ---
+  OK: go version go1.25.x linux/arm64
+  OK: libprotoc 3.x.x
+  OK: protoc-gen-go
+  OK: protoc-gen-go-grpc
+  OK: Node.js v20.x.x
+  OK: Python 3.x.x
+  OK: pnpm x.x.x
+
+--- Layer 2 (Native C/C++) ---
+  OK: cmake version 3.x.x
+  OK: g++ (Ubuntu 13.x / Apple clang) x.x.x
+  OK: grpc_cpp_plugin
+
+--- Layer 3 (Hailo-15 Cross-compile) ---
+  OK: Hailo SDK (/opt/hailo-sdk)
+```
+
+> The above is the output from the Docker pre-built image (Option A). Under manual install (Option C), Layer 3 shows `OK: Hailo SDK (/opt/poky/4.0.23)` — both paths are valid.
+
+If Layer 3 is not installed, you will see:
+
+```plaintext
+--- Layer 3 (Hailo-15 Cross-compile) ---
+  NOT FOUND: Hailo SDK
+```
+
+Missing Layer 3 only affects full release builds (`pack-release`), not Go service or Web console development.
+
+> If you see `WARNING: hailo15 target requested`, a stale `Makefile.docker` exists in the project root. Remove it: `rm Makefile.docker`.
+
+### 5. Python SDK & IDE Configuration
+
+> Run the commands below inside your dev environment: Docker users first enter the container with `docker exec -it ne503-dev bash`; native users run from the project root.
+
+#### Python SDK (development mode)
+
+```bash
+cd sdk/python
+pip3 install -e ".[dev]"
+```
+
+> On `error: externally-managed-environment` (Ubuntu 24.04+, macOS Homebrew Python), use a venv:
+>
+> ```bash
+> cd sdk/python
+> python3 -m venv .venv && source .venv/bin/activate
+> pip install -e ".[dev]"
+> ```
+>
+> Run `deactivate` when done; re-run `source .venv/bin/activate` before each development session.
+
+#### Recommended IDE
+
+VS Code with extensions:
+
+- Go — `golang.go`
+- Python — `ms-python.python`
+- C/C++ — `ms-vscode.cpptools`
+- CMake Tools — `ms-vscode.cmake-tools`
+- Protocol Buffers — `bufbuild.vscode-buf`
+
+## Part B: Release Build
+
+### 6. Full Build
+
+The build produces `build/release/aipc-hailo15-<version>.tar.gz` containing platform services, HAL libraries, Web console, and deployment scripts.
+
+#### In-container build (recommended, all platforms)
+
+Run inside the `ne503-dev` container created in Option A — works identically on Ubuntu / macOS Intel / Apple Silicon:
+
+```bash
+docker exec ne503-dev bash -c \
+  'source /opt/hailo-sdk/environment-setup-armv8a-poky-linux && \
+   make pack-release SDK_PATH=/opt/hailo-sdk VERSION=1.0.0'
+```
+
+```plaintext
+# Expected output (stage progress; per-file compile lines omitted)
+==> Compiling proto (inference / device / event / camera / app / ...)
+==> Building device-control (CGO_ENABLED=0)
+==> Building event-bus / app-manager / platform-api / device-discovery
+==> Building Web Console
+==> Building Python SDK
+=== Layer 1 complete: proto + Go services + web + Python SDK ===
+==> Building HAL v2 [platform=hailo15]
+==> Building camera-daemon / ai-runtime (C++) / aipc-cli
+==> Building tools (shm-reader, nv12-to-jpeg)
+=== Layer 2 complete ===
+==> Packaging release [1.0.0, platform=hailo15]
+=== Release Package Ready ===
+File:   build/release/aipc-hailo15-1.0.0.tar.gz (111M)
+```
+
+> Under manual install (Option C), the SDK path is `/opt/poky/4.0.23` — replace the env script and `SDK_PATH` in the command above with that path.
+
+#### Verify Build Artifacts
+
+Confirm binaries are ARM aarch64 (the container has no `file`, use `readelf`):
+
+```bash
+docker exec ne503-dev bash -c \
+  'readelf -h build/output/device-control | grep Machine'
+# Expected output: Machine: AArch64
+```
+
+All artifacts under `build/output/` (Go/C++ services, `aipc-cli`, `shm-reader`, `hal/hailo15/libaipc_hal.so`) are aarch64. On the host (outside the container) you can also run `file build/output/device-control` (output contains `ARM aarch64`).
+
+### 7. Individual Service Builds
+
+During development iteration, rebuild and replace only the service you're working on:
+
+```bash
+# Device management
+make device-control HAL_PLATFORM=hailo15
+
+# Event bus
+make event-bus HAL_PLATFORM=hailo15
+
+# App management
+make app-manager HAL_PLATFORM=hailo15
+
+# API gateway
+make platform-api HAL_PLATFORM=hailo15
+
+# Device discovery
+make device-discovery HAL_PLATFORM=hailo15
+
+# Video capture (source SDK environment first)
+source /opt/hailo-sdk/environment-setup-armv8a-poky-linux
+make camera-daemon HAL_PLATFORM=hailo15 SDK_PATH=/opt/hailo-sdk
+
+# AI inference (source SDK environment first)
+source /opt/hailo-sdk/environment-setup-armv8a-poky-linux
+make ai-runtime HAL_PLATFORM=hailo15 SDK_PATH=/opt/hailo-sdk
+```
+
+> `HAL_PLATFORM=hailo15` automatically sets cross-compile parameters. Run these commands inside the container or on a Linux host with the SDK environment sourced; macOS users should first enter the container with `docker exec -it ne503-dev bash`.
+
+### 8. Build Troubleshooting
+
+#### protoc / protoc-gen-go not found
+
+```bash
+sudo apt install protobuf-compiler
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+export PATH="$PATH:$(go env GOPATH)/bin"
+```
+
+#### grpc_cpp_plugin not found
+
+```bash
+sudo apt install protobuf-compiler-grpc libgrpc++-dev libprotobuf-dev
+```
+
+#### camera-daemon cross-compile protobuf version mismatch
+
+C++ proto files must be generated with the SDK's bundled protoc. The Makefile handles this automatically when `HAL_PLATFORM=hailo15`.
+
+If auto-generation fails, run the matching proto target manually (e.g. `make proto-camera`), or run `make help` to list the `proto-*` series.
+
+#### CMake selected wrong toolchain
+
+```bash
+rm -rf platform/camera-daemon/build-hailo15
+make camera-daemon HAL_PLATFORM=hailo15 SDK_PATH=/opt/hailo-sdk
+```
+
+#### pnpm reports "Ignored build scripts" on first run
+
+```bash
+cd web && pnpm approve-builds esbuild msw unrs-resolver
+```
+
+#### Web console build fails (missing modules)
+
+`pnpm build` reports `Cannot find module '.../lib/...'`. The root cause is the `.gitignore` `lib/` rule catching `web/src/**/lib/`, so those source files are not tracked by git. Confirm `.gitignore` has the un-ignore exception:
+
+```gitignore
+lib/
+!web/src/**/lib/
+```
+
+Add the exception, re-pull, and `pnpm build` works again.
+
+#### Python SDK docs build reports ModuleNotFoundError: grpc
+
+The `Building Python SDK Documentation` stage prints many `ModuleNotFoundError: No module named 'grpc'` lines — sphinx autodoc tries to import SDK modules without `grpcio` installed. **Non-fatal**: the Python SDK itself builds successfully, the docs are still generated, and the build continues into Layer 2; the final release package is unaffected. Safe to ignore.
+
+### Make Target Reference
+
+| Target | Description |
+|--------|-------------|
+| `make pack-release` | Full Hailo-15 release (build + package) |
+| `make pack` | Package from existing build artifacts (no SDK needed) |
+| `make platform` | All Go services |
+| `make hal-v2` | HAL v2 (`HAL_PLATFORM=hailo15` cross-compile) |
+| `make camera-daemon` | C++ camera-daemon |
+| `make ai-runtime` | C++ AI inference service |
+| `make proto` | Compile .proto to Go code |
+| `make web` | Web console (pnpm) |
+| `make layer1` | proto + Go + Web + Python SDK |
+| `make layer2` | Layer 1 + HAL stub + C++ components |
+| `make env-check` | Check build dependencies |
+| `make clean` | Clean build artifacts |
+| `make test` | Run all tests |
+
+## Related Documentation
+
+- [System Architecture](./0-system-architecture.md) — Four-layer architecture and core services
+- [System Flashing](./2-system-flashing.md) — System image flashing and upgrades
+- [Software Deployment](./3-software-deployment.md) — Platform software deployment and iterative development
+- [Config Reference](./4-reference/1-config-reference.md) — Service configuration parameters
+- [Troubleshooting](./4-reference/0-troubleshooting.md) — Runtime issue diagnostics

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/3-software-guide/_category_.json
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/3-software-guide/_category_.json
@@ -1,0 +1,1 @@
+{"label":"Software Guide","position":3}


### PR DESCRIPTION
## Summary

Adds the first two reviewed documents of the NE503 **Software Guide** (`3-software-guide/`), bilingual (zh-Hans default + en):

- **`0-system-architecture.md`** — four-layer platform architecture, 7 core services, HAL v2 hardware abstraction, Python SDK, container security model, zero-copy / DMA-BUF pipeline, multi-SoC support.
- **`1-developer-guide.md`** — full environment setup (Docker pre-built image / script / manual), the three-layer build model, `pack-release` end-to-end packaging, and build troubleshooting.
- **`_category_.json`** — sidebar entry, position 3.

The `3-software-guide/` directory does not yet exist on `main`; this PR creates it.

## Cross-links & follow-up

These two documents cross-link to sibling docs that are **not** in this PR (reviewed separately, will follow):

- `2-system-flashing.md`, `3-software-deployment.md`
- `4-reference/` (config / CLI / troubleshooting / service-reference / benchmarks / faq)
- `../4-application-guide/` (app development, SDK reference, RESTful API)

`onBrokenLinks` is `'warn'` in `docusaurus.config.js`, so the production build passes with link warnings; the links resolve automatically once those docs land in follow-up PRs.

## Build verification

Verified locally with a clean checkout of `upstream/main` + these 6 files: the `en` locale build succeeds (`[SUCCESS] Generated static files`); only the expected forward-reference link warnings are emitted. No images are referenced by either document, so no missing-asset errors.

## Test plan

- [ ] Review `0-system-architecture.md` (zh + en) for technical accuracy
- [ ] Review `1-developer-guide.md` (zh + en) — build commands, Docker workflow, troubleshooting
- [ ] Confirm sidebar shows "Software Guide" under NE503 series at position 3
- [ ] Confirm `yarn build` passes (warnings only)