### PR TITLE
docs(neomind/ne503): 撤回 #159 预编译包提示并清理 2-3rd-party-integration 悬空链接

### DIFF
--- a/docs/6-neoeyes-ne503-series/3-software-guide/0-system-architecture.md
+++ b/docs/6-neoeyes-ne503-series/3-software-guide/0-system-architecture.md
@@ -213,5 +213,4 @@ Event Bus 采用发布/订阅模式，支持 MQTT 风格通配符匹配：
 
 - [应用开发指南](../4-application-guide/1-app-development/reference/1-app-reference.md) — 如何编写和部署容器应用
 - [Python SDK 参考](../4-application-guide/1-app-development/reference/2-sdk-reference.md) — SDK API 签名与使用示例
-- [RESTful API 参考](../4-application-guide/2-3rd-party-integration/0-restful-api.md) — HTTP API 端点完整参考
 - [平台服务总览](./4-reference/0-platform-services.md) — 各服务职责、协作关系与源码指针

--- a/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/1-hello-world.md
+++ b/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/1-hello-world.md
@@ -13,10 +13,6 @@ tags: [应用开发, NE503, 教程, 入门]
 
 Hello World 不依赖 AI SDK，在一个循环中持续打印计数，用于验证开发环境与部署流程是否打通。
 
-:::tip 跳过构建，直接体验
-不想自己 build 镜像？下载预编译包 [hello-world.tar](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/application-guide/app-development/hello-world/hello-world.tar)，解压即得 `app.yaml` 与 `image.tar`，按 §4 部署到设备即可。
-:::
-
 ## 1. 前置条件
 
 | 条件 | 验证方法 |

--- a/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/2-person-detection.md
+++ b/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/2-person-detection.md
@@ -11,10 +11,6 @@ tags: [应用开发, NE503, 教程, AI 推理, SDK]
 
 本教程部署一个**真实的 AI 推理应用** Person Detection，完整演示：通过 Python SDK 订阅视频流推理结果、发现设备上的模型与流、配置应用权限，并验收一个会发布检测事件、联动设备灯控的完整应用。
 
-:::tip 跳过构建，直接体验
-不想自己 build 镜像？下载预编译包 [person-detection.tar](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/application-guide/app-development/person-detection/person-detection.tar)，解压即得 `app.yaml` 与 `image.tar`，按 §5 部署到设备即可。
-:::
-
 ## 1. 功能概述
 
 Person Detection 订阅摄像头视频流，用 AI 检测模型逐帧推理，当画面中出现人时：

--- a/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/3-ai-assisted-dev.md
+++ b/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/3-ai-assisted-dev.md
@@ -13,10 +13,6 @@ tags: [应用开发, NE503, AI 辅助开发, skill]
 
 演示应用为 **停留告警**（Loitering Detection）：检测到人员连续停留 10 秒即触发告警，人员离开后重置。
 
-:::tip 直接体验成品
-想跳过开发过程、直接部署成品？下载本次演示产出的预编译包 [occupancy-monitor.tar](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/application-guide/app-development/ai-assisted-dev/occupancy-monitor.tar)，解压即得 `app.yaml` 与 `image.tar`，按 [Hello World](./1-hello-world.md) §4 的步骤部署到设备即可。
-:::
-
 ## 1. 前置准备
 
 | 条件 | 说明 |

--- a/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/reference/2-sdk-reference.md
+++ b/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/reference/2-sdk-reference.md
@@ -283,7 +283,7 @@ class EncodedStreamClient:
     def close() -> None
 ```
 
-`FdMediaClient.get_encoded_stream(stream_id="main")` 可便捷返回一个已连接的 `EncodedStreamClient`。视频流接入（RTSP/WebSocket）详见 [Video Integration](../../2-3rd-party-integration/1-video-integration.md)。
+`FdMediaClient.get_encoded_stream(stream_id="main")` 可便捷返回一个已连接的 `EncodedStreamClient`。视频流接入（RTSP/WebSocket）详见 Video Integration（即将发布）。
 
 ---
 

--- a/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/reference/troubleshooting.md
+++ b/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/reference/troubleshooting.md
@@ -67,7 +67,7 @@ aipc-cli app info <app-id>
 
 ### 2.1 WebSocket 断连
 
-WebSocket 断连常见于客户端超时、服务端报错或网络波动；接入侧（含推荐的重连策略）见 [视频集成](../../2-3rd-party-integration/1-video-integration.md)。
+WebSocket 断连常见于客户端超时、服务端报错或网络波动；接入侧（含推荐的重连策略）见「视频集成」（即将发布）。
 
 **诊断命令：**
 
@@ -222,6 +222,4 @@ ssh root@$IP "journalctl -u camera-daemon -n 20 --no-pager"             # 摄像
 ## 相关文档
 
 - [应用参考](./1-app-reference.md) — 应用配置和部署流程
-- [Video Integration](../../2-3rd-party-integration/1-video-integration.md) — 视频流接入指南
-- [Event Integration](../../2-3rd-party-integration/2-event-integration.md) — 事件总线接入指南
 - [Platform Troubleshooting](../../../3-software-guide/4-reference/1-troubleshooting.md) — 平台服务故障排查

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/3-software-guide/0-system-architecture.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/3-software-guide/0-system-architecture.md
@@ -213,5 +213,4 @@ Installation path: `/opt/aipc/` (binaries in `bin/`, configuration in `etc/`).
 
 - [Application Development Guide](../4-application-guide/1-app-development/reference/1-app-reference.md) — How to write and deploy container applications
 - [Python SDK Reference](../4-application-guide/1-app-development/reference/2-sdk-reference.md) — SDK API signatures and usage examples
-- [RESTful API Reference](../4-application-guide/2-3rd-party-integration/0-restful-api.md) — Complete HTTP API endpoint reference
 - [Platform Services Overview](./4-reference/0-platform-services.md) — Service responsibilities, collaboration, and source pointers

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/1-hello-world.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/1-hello-world.md
@@ -13,10 +13,6 @@ This tutorial uses a minimal Hello World application to demonstrate the **comple
 
 Hello World does not depend on the AI SDK — it prints a counter in a loop, used to verify that the development environment and deployment pipeline work end to end.
 
-:::tip Skip the build, try it directly
-Don't want to build the image yourself? Download the prebuilt package [hello-world.tar](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/application-guide/app-development/hello-world/hello-world.tar), unzip it to get `app.yaml` and `image.tar`, and follow §4 to deploy to the device.
-:::
-
 ## 1. Prerequisites
 
 | Condition | Verification |

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/2-person-detection.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/2-person-detection.md
@@ -11,10 +11,6 @@ tags: [application development, NE503, tutorial, AI inference, SDK]
 
 This tutorial deploys a **real AI inference application** Person Detection, demonstrating the complete workflow: subscribing to video stream inference results via the Python SDK, discovering models and streams on the device, configuring application permissions, and verifying a complete application that publishes detection events and triggers the device light control.
 
-:::tip Skip the build, try it directly
-Don't want to build the image yourself? Download the prebuilt package [person-detection.tar](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/application-guide/app-development/person-detection/person-detection.tar), unzip it to get `app.yaml` and `image.tar`, and follow §5 to deploy to the device.
-:::
-
 ## 1. Overview
 
 Person Detection subscribes to the camera video stream and runs AI detection model inference frame by frame. When a person appears in the frame:

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/3-ai-assisted-dev.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/3-ai-assisted-dev.md
@@ -13,10 +13,6 @@ This page demonstrates **AI-assisted development**: describe the requirement in 
 
 The demo app is a **loitering alert** (Loitering Detection): when a person stays in frame continuously for 10 seconds, it fires an alert; when they leave, it resets.
 
-:::tip Try the finished app directly
-Want to skip development and deploy the finished app right away? Download the prebuilt package [occupancy-monitor.tar](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/application-guide/app-development/ai-assisted-dev/occupancy-monitor.tar), unzip it to get `app.yaml` and `image.tar`, and follow the steps in [Hello World](./1-hello-world.md) §4 to deploy to the device.
-:::
-
 ## 1. Prerequisites
 
 | Prerequisite | Description |

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/reference/2-sdk-reference.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/reference/2-sdk-reference.md
@@ -283,7 +283,7 @@ class EncodedStreamClient:
     def close() -> None
 ```
 
-`FdMediaClient.get_encoded_stream(stream_id="main")` conveniently returns a connected `EncodedStreamClient`. For video stream integration (RTSP/WebSocket), see [Video Integration](../../2-3rd-party-integration/1-video-integration.md).
+`FdMediaClient.get_encoded_stream(stream_id="main")` conveniently returns a connected `EncodedStreamClient`. For video stream integration (RTSP/WebSocket), see Video Integration (coming soon).
 
 ---
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/reference/troubleshooting.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/reference/troubleshooting.md
@@ -64,7 +64,7 @@ aipc-cli app info <app-id>
 
 ### 2.1 WebSocket Disconnection
 
-WebSocket disconnection is usually client timeout, a server-side error, or network fluctuation; for the integration side (including the recommended reconnection strategy), see [Video Integration](../../2-3rd-party-integration/1-video-integration.md).
+WebSocket disconnection is usually client timeout, a server-side error, or network fluctuation; for the integration side (including the recommended reconnection strategy), see Video Integration (coming soon).
 
 **Diagnostic commands:**
 
@@ -219,6 +219,4 @@ ssh root@$IP "journalctl -u camera-daemon -n 20 --no-pager"             # camera
 ## Related Documentation
 
 - [App Reference](./1-app-reference.md) — App configuration and deployment workflow
-- [Video Integration](../../2-3rd-party-integration/1-video-integration.md) — Video stream integration guide
-- [Event Integration](../../2-3rd-party-integration/2-event-integration.md) — Event bus integration guide
 - [Platform Troubleshooting](../../../3-software-guide/4-reference/1-troubleshooting.md) — Platform service troubleshooting


### PR DESCRIPTION
## 背景
两个相关问题的收尾,均为 NE503 文档针对最近一轮 CI 断链的处理。

## 改动

### 1. Revert #159(撤回预编译包提示)
撤回 #159 为 Hello World / Person Detection / AI-Assisted Development 三篇教程添加的「使用预编译镜像包」提示,恢复到加提示前的状态。三篇教程正文内容不受影响。

### 2. 删除 2-3rd-party-integration 悬空链接(CI 断链根因)
`4-application-guide/2-3rd-party-integration/`(RESTful API / Video Integration / Event Integration)目录尚未完成,已提交文档中指向这些页面的 10 处链接会让 CI 的 broken-link 检查失败。

- 删除 4 处「相关文档」列表项(system-architecture、troubleshooting,中英)
- 将 4 处正文引用(sdk-reference、troubleshooting,中英)改为纯文本 + 标注「即将发布 / coming soon」,保留语义、去掉失效链接

> 该目录文档完成后,会单独再开 PR 恢复这些链接。

## Test plan
- [ ] CI build 通过(broken-link 不再报 2-3rd-party-integration)
- [ ] 本地 `yarn build` 通过
- [ ] 抽查 troubleshooting / system-architecture / sdk-reference 中英页面渲染正常