### PR TITLE
docs(neomind/app-development): Restore the precompiled package tips for 3 tutorials

### DIFF
--- a/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/1-hello-world.md
+++ b/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/1-hello-world.md
@@ -13,6 +13,10 @@ tags: [应用开发, NE503, 教程, 入门]
 
 Hello World 不依赖 AI SDK，在一个循环中持续打印计数，用于验证开发环境与部署流程是否打通。
 
+:::tip 跳过构建，直接体验
+不想自己 build 镜像？下载预编译包 [hello-world.tar](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/application-guide/app-development/hello-world/hello-world.tar)，解压即得 `app.yaml` 与 `image.tar`，按 §4 部署到设备即可。
+:::
+
 ## 1. 前置条件
 
 | 条件 | 验证方法 |

--- a/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/2-person-detection.md
+++ b/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/2-person-detection.md
@@ -11,6 +11,10 @@ tags: [应用开发, NE503, 教程, AI 推理, SDK]
 
 本教程部署一个**真实的 AI 推理应用** Person Detection，完整演示：通过 Python SDK 订阅视频流推理结果、发现设备上的模型与流、配置应用权限，并验收一个会发布检测事件、联动设备灯控的完整应用。
 
+:::tip 跳过构建，直接体验
+不想自己 build 镜像？下载预编译包 [person-detection.tar](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/application-guide/app-development/person-detection/person-detection.tar)，解压即得 `app.yaml` 与 `image.tar`，按 §5 部署到设备即可。
+:::
+
 ## 1. 功能概述
 
 Person Detection 订阅摄像头视频流，用 AI 检测模型逐帧推理，当画面中出现人时：

--- a/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/3-ai-assisted-dev.md
+++ b/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/3-ai-assisted-dev.md
@@ -13,6 +13,10 @@ tags: [应用开发, NE503, AI 辅助开发, skill]
 
 演示应用为 **停留告警**（Loitering Detection）：检测到人员连续停留 10 秒即触发告警，人员离开后重置。
 
+:::tip 直接体验成品
+想跳过开发过程、直接部署成品？下载本次演示产出的预编译包 [occupancy-monitor.tar](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/application-guide/app-development/ai-assisted-dev/occupancy-monitor.tar)，解压即得 `app.yaml` 与 `image.tar`，按 [Hello World](./1-hello-world.md) §4 的步骤部署到设备即可。
+:::
+
 ## 1. 前置准备
 
 | 条件 | 说明 |

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/1-hello-world.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/1-hello-world.md
@@ -13,6 +13,10 @@ This tutorial uses a minimal Hello World application to demonstrate the **comple
 
 Hello World does not depend on the AI SDK — it prints a counter in a loop, used to verify that the development environment and deployment pipeline work end to end.
 
+:::tip Skip the build, try it directly
+Don't want to build the image yourself? Download the prebuilt package [hello-world.tar](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/application-guide/app-development/hello-world/hello-world.tar), unzip it to get `app.yaml` and `image.tar`, and follow §4 to deploy to the device.
+:::
+
 ## 1. Prerequisites
 
 | Condition | Verification |

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/2-person-detection.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/2-person-detection.md
@@ -11,6 +11,10 @@ tags: [application development, NE503, tutorial, AI inference, SDK]
 
 This tutorial deploys a **real AI inference application** Person Detection, demonstrating the complete workflow: subscribing to video stream inference results via the Python SDK, discovering models and streams on the device, configuring application permissions, and verifying a complete application that publishes detection events and triggers the device light control.
 
+:::tip Skip the build, try it directly
+Don't want to build the image yourself? Download the prebuilt package [person-detection.tar](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/application-guide/app-development/person-detection/person-detection.tar), unzip it to get `app.yaml` and `image.tar`, and follow §5 to deploy to the device.
+:::
+
 ## 1. Overview
 
 Person Detection subscribes to the camera video stream and runs AI detection model inference frame by frame. When a person appears in the frame:

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/3-ai-assisted-dev.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/3-ai-assisted-dev.md
@@ -13,6 +13,10 @@ This page demonstrates **AI-assisted development**: describe the requirement in 
 
 The demo app is a **loitering alert** (Loitering Detection): when a person stays in frame continuously for 10 seconds, it fires an alert; when they leave, it resets.
 
+:::tip Try the finished app directly
+Want to skip development and deploy the finished app right away? Download the prebuilt package [occupancy-monitor.tar](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/application-guide/app-development/ai-assisted-dev/occupancy-monitor.tar), unzip it to get `app.yaml` and `image.tar`, and follow the steps in [Hello World](./1-hello-world.md) §4 to deploy to the device.
+:::
+
 ## 1. Prerequisites
 
 | Prerequisite | Description |


### PR DESCRIPTION
## Background
#160 revert #159(96756383) when reverting #159, tip the "precompiled package" of the three tutorials Hello World/Person Detection/AI-Assisted Development It was also withdrawn (a total of 6 articles in both Chinese and English). These tips themselves are fine (they have passed the review and are the b56a62d7 fixed version), and should be retained.

"## Modification
Use 'git revert 96756383' to precisely restore the 24 lines deleted by revert, and add the tips of the 6 tutorials back as they are:
-CN +EN 3 articles each, and restore 1 ':::tip' block for each article
- Content is a fixed version: Download the precompiled package → Extract to obtain 'app.yaml' and 'image.tar' → Deploy as per §4

#160 The deleted 2-3d-Party-Integration dangling links are not affected and remain deleted.

## Test plan
- [] CI build passed
The Chinese and English page tips for the three tutorials are rendered normally
The link to the precompiled package (hello-world.tar/person-detection.tar/occupancy-monitor.tar) is available