### PR TITLE
Update prebuilt package link to lingering-detection

### DIFF
--- a/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/3-ai-assisted-dev.md
+++ b/docs/6-neoeyes-ne503-series/4-application-guide/1-app-development/3-ai-assisted-dev.md
@@ -14,7 +14,7 @@ tags: [应用开发, NE503, AI 辅助开发, skill]
 演示应用为 **停留告警**（Loitering Detection）：检测到人员连续停留 10 秒即触发告警，人员离开后重置。
 
 :::tip 直接体验成品
-想跳过开发过程、直接部署成品？下载本次演示产出的预编译包 [occupancy-monitor.tar](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/application-guide/app-development/ai-assisted-dev/occupancy-monitor.tar)，解压即得 `app.yaml` 与 `image.tar`，按 [Hello World](./1-hello-world.md) §4 的步骤部署到设备即可。
+想跳过开发过程、直接部署成品？下载本次演示产出的预编译包 [lingering-detection.tar](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/application-guide/app-development/ai-assisted-dev/lingering-detection.tar)，解压即得 `app.yaml` 与 `image.tar`，按 [Hello World](./1-hello-world.md) §4 的步骤部署到设备即可。
 :::
 
 ## 1. 前置准备

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/3-ai-assisted-dev.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/4-application-guide/1-app-development/3-ai-assisted-dev.md
@@ -14,7 +14,7 @@ This page demonstrates **AI-assisted development**: describe the requirement in 
 The demo app is a **loitering alert** (Loitering Detection): when a person stays in frame continuously for 10 seconds, it fires an alert; when they leave, it resets.
 
 :::tip Try the finished app directly
-Want to skip development and deploy the finished app right away? Download the prebuilt package [occupancy-monitor.tar](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/application-guide/app-development/ai-assisted-dev/occupancy-monitor.tar), unzip it to get `app.yaml` and `image.tar`, and follow the steps in [Hello World](./1-hello-world.md) §4 to deploy to the device.
+Want to skip development and deploy the finished app right away? Download the prebuilt package [lingering-detection.tar](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/application-guide/app-development/ai-assisted-dev/lingering-detection.tar), unzip it to get `app.yaml` and `image.tar`, and follow the steps in [Hello World](./1-hello-world.md) §4 to deploy to the device.
 :::
 
 ## 1. Prerequisites


### PR DESCRIPTION
Update the documentation to reflect the correct link for the prebuilt package, changing it from occupancy-monitor to lingering-detection.