### PR TITLE
Update schematic and PCB file links to lowercase

### DIFF
--- a/docs/2-neoeyes-ne101-series/0-overview.md
+++ b/docs/2-neoeyes-ne101-series/0-overview.md
@@ -533,9 +533,9 @@ NE101整机产品规格如下：
 
 关于NE101系列产品的应用场景与指南可见[「应用指南」](./3-application-guide/0-low-power-image-acquisition.md)
 
-NE101原理图[「下载」](https://resources.camthink.ai/wiki/doc/NE101-Schematic-Open.pdf)
+NE101原理图[「下载」](https://resources.camthink.ai/wiki/doc/ne101-schematic-open.pdf)
 
-NE101PCB文件[「下载」](https://resources.camthink.ai/wiki/doc/Ne101-PCB-Open.pdf)
+NE101PCB文件[「下载」](https://resources.camthink.ai/wiki/doc/ne101-pcb-open.pdf)
 
 
 <!-- ### 产品资源

--- a/docs/5-neoeyes-ne301-series/0-overview.md
+++ b/docs/5-neoeyes-ne301-series/0-overview.md
@@ -530,8 +530,8 @@ Alarm 报警触发
   - 硬件指南：
     - [组件总览](./2-NE300-MB01-development-board/1-hardware-guide/0-components-overview.md)
     - [硬件连接](./2-NE300-MB01-development-board/1-hardware-guide/1-hardware-connection.md)
-    - NE301原理图[「下载」](https://resources.camthink.ai/wiki/doc/ne301-schematic-open.pdf?_gl=1*wj62ex*_gcl_au*NzQ0NTgzNzY2LjE3ODMzOTU2MjQ.*_ga*MTk5MDkwODE4My4xNzgzMzk1NjI0*_ga_XBWTN65KKB*czE3ODMzOTU2MjQkbzEkZzEkdDE3ODM0ODg5MzEkajE0JGwwJGgw)
-    - NE301PCB文件[「下载」](https://resources.camthink.ai/wiki/doc/ne301-pcb-open.pdf?_gl=1*1bbzhsj*_gcl_au*NzQ0NTgzNzY2LjE3ODMzOTU2MjQ.*_ga*MTk5MDkwODE4My4xNzgzMzk1NjI0*_ga_XBWTN65KKB*czE3ODMzOTU2MjQkbzEkZzEkdDE3ODM0ODkzMSQ)
+    - NE301原理图[「下载」](https://resources.camthink.ai/wiki/doc/ne301-schematic-open.pdf)
+    - NE301PCB文件[「下载」](https://resources.camthink.ai/wiki/doc/ne301-pcb-open.pdf)
   - 软件指南：
     - [开发环境搭建](./2-NE300-MB01-development-board/2-software-guide/0-development-environment-setup.md)
     - [系统烧录与初始化](./2-NE300-MB01-development-board/2-software-guide/1-system-flashing-and-initialization.md)

--- a/docs/5-neoeyes-ne301-series/0-overview.md
+++ b/docs/5-neoeyes-ne301-series/0-overview.md
@@ -530,8 +530,8 @@ Alarm 报警触发
   - 硬件指南：
     - [组件总览](./2-NE300-MB01-development-board/1-hardware-guide/0-components-overview.md)
     - [硬件连接](./2-NE300-MB01-development-board/1-hardware-guide/1-hardware-connection.md)
-    - NE301原理图[「下载」](https://resources.camthink.ai/wiki/doc/NE301-Schematic-Open.pdf)
-    - NE301PCB文件[「下载」](https://resources.camthink.ai/wiki/doc/NE301-PCB-Open.pdf)
+    - NE301原理图[「下载」](https://resources.camthink.ai/wiki/doc/ne301-schematic-open.pdf?_gl=1*wj62ex*_gcl_au*NzQ0NTgzNzY2LjE3ODMzOTU2MjQ.*_ga*MTk5MDkwODE4My4xNzgzMzk1NjI0*_ga_XBWTN65KKB*czE3ODMzOTU2MjQkbzEkZzEkdDE3ODM0ODg5MzEkajE0JGwwJGgw)
+    - NE301PCB文件[「下载」](https://resources.camthink.ai/wiki/doc/ne301-pcb-open.pdf?_gl=1*1bbzhsj*_gcl_au*NzQ0NTgzNzY2LjE3ODMzOTU2MjQ.*_ga*MTk5MDkwODE4My4xNzgzMzk1NjI0*_ga_XBWTN65KKB*czE3ODMzOTU2MjQkbzEkZzEkdDE3ODM0ODkzMSQ)
   - 软件指南：
     - [开发环境搭建](./2-NE300-MB01-development-board/2-software-guide/0-development-environment-setup.md)
     - [系统烧录与初始化](./2-NE300-MB01-development-board/2-software-guide/1-system-flashing-and-initialization.md)

--- a/i18n/en/docusaurus-plugin-content-docs/current/2-neoeyes-ne101-series/0-overview.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/2-neoeyes-ne101-series/0-overview.md
@@ -546,9 +546,9 @@ About how to use the NE100-MB01 motherboard and its related hardware and system 
 
 About the application scenarios and guidelines for NE101 series products, please refer to[「Application Guide」](./3-application-guide/0-low-power-image-acquisition.md)
 
-NE101 Schematic [「Download」](https://resources.camthink.ai/wiki/doc/NE101-Schematic-Open.pdf)
+NE101 Schematic [「Download」](https://resources.camthink.ai/wiki/doc/ne101-schematic-open.pdf)
 
-NE101 PCB File [「Download」](https://resources.camthink.ai/wiki/doc/Ne101-PCB-Open.pdf)
+NE101 PCB File [「Download」](https://resources.camthink.ai/wiki/doc/ne101-pcb-open.pdf)
 
 
 <!-- ### 产品资源

--- a/i18n/en/docusaurus-plugin-content-docs/current/5-neoeyes-ne301-series/0-overview.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/5-neoeyes-ne301-series/0-overview.md
@@ -514,8 +514,8 @@ NeoEyes NE301 delivers on-device AI while maintaining ultra-low power consumptio
   - Hardware Guide:
     - [Components Overview](./2-NE300-MB01-development-board/1-hardware-guide/0-components-overview.md)
     - [Hardware Connection](./2-NE300-MB01-development-board/1-hardware-guide/1-hardware-connection.md)
-    - NE301 Schematic [「Download」](https://resources.camthink.ai/wiki/doc/ne301-schematic-open.pdf?_gl=1*wj62ex*_gcl_au*NzQ0NTgzNzY2LjE3ODMzOTU2MjQ.*_ga*MTk5MDkwODE4My4xNzgzMzk1NjI0*_ga_XBWTN65KKB*czE3ODMzOTU2MjQkbzEkZzEkdDE3ODM0ODg5MzEkajE0JGwwJGgw)
-    - NE301 PCB File [「Download」](https://resources.camthink.ai/wiki/doc/ne301-pcb-open.pdf?_gl=1*1bbzhsj*_gcl_au*NzQ0NTgzNzY2LjE3ODMzOTU2MjQ.*_ga*MTk5MDkwODE4My4xNzgzMzk1NjI0*_ga_XBWTN65KKB*czE3ODMzOTU2MjQkbzEkZzEkdDE3ODM0ODkzMSQ)
+    - NE301 Schematic [「Download」](https://resources.camthink.ai/wiki/doc/ne301-schematic-open.pdf)
+    - NE301 PCB File [「Download」](https://resources.camthink.ai/wiki/doc/ne301-pcb-open.pdf)
   - Software Guide:
     - [Development Environment Setup](./2-NE300-MB01-development-board/2-software-guide/0-development-environment-setup.md)
     - [System Flashing And Initialization](./2-NE300-MB01-development-board/2-software-guide/1-system-flashing-and-initialization.md)

--- a/i18n/en/docusaurus-plugin-content-docs/current/5-neoeyes-ne301-series/0-overview.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/5-neoeyes-ne301-series/0-overview.md
@@ -514,8 +514,8 @@ NeoEyes NE301 delivers on-device AI while maintaining ultra-low power consumptio
   - Hardware Guide:
     - [Components Overview](./2-NE300-MB01-development-board/1-hardware-guide/0-components-overview.md)
     - [Hardware Connection](./2-NE300-MB01-development-board/1-hardware-guide/1-hardware-connection.md)
-    - NE301 Schematic [「Download」](https://resources.camthink.ai/wiki/doc/NE301-Schematic-Open.pdf)
-    - NE301 PCB File [「Download」](https://resources.camthink.ai/wiki/doc/NE301-PCB-Open.pdf)
+    - NE301 Schematic [「Download」](https://resources.camthink.ai/wiki/doc/ne301-schematic-open.pdf?_gl=1*wj62ex*_gcl_au*NzQ0NTgzNzY2LjE3ODMzOTU2MjQ.*_ga*MTk5MDkwODE4My4xNzgzMzk1NjI0*_ga_XBWTN65KKB*czE3ODMzOTU2MjQkbzEkZzEkdDE3ODM0ODg5MzEkajE0JGwwJGgw)
+    - NE301 PCB File [「Download」](https://resources.camthink.ai/wiki/doc/ne301-pcb-open.pdf?_gl=1*1bbzhsj*_gcl_au*NzQ0NTgzNzY2LjE3ODMzOTU2MjQ.*_ga*MTk5MDkwODE4My4xNzgzMzk1NjI0*_ga_XBWTN65KKB*czE3ODMzOTU2MjQkbzEkZzEkdDE3ODM0ODkzMSQ)
   - Software Guide:
     - [Development Environment Setup](./2-NE300-MB01-development-board/2-software-guide/0-development-environment-setup.md)
     - [System Flashing And Initialization](./2-NE300-MB01-development-board/2-software-guide/1-system-flashing-and-initialization.md)


### PR DESCRIPTION
Standardize the links to the schematic and PCB files in the overview documents by converting them to lowercase. This change improves consistency and accessibility.