### PR TITLE
docs(ne503): add ST-LINK/SWD port location image to MCU flashing guide

### DIFF
--- a/docs/6-neoeyes-ne503-series/3-software-guide/2-system-flashing.md
+++ b/docs/6-neoeyes-ne503-series/3-software-guide/2-system-flashing.md
@@ -424,6 +424,9 @@ reset
 ### 4.1 准备
 
 - **硬件**：ST-LINK 调试器（V2/V3），接到接口板的 SWD 调试口（PA13/SWDIO、PA14/SWDCLK·BOOT0、NRST、GND、3V3 VREF）。引脚定义见 [AIPC Board Connection](../2-hardware-guide/2-aipc-board-connection.md)。
+
+![接口板 ST-LINK（SWD 调试口）接入位置](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/software-guide/system-flashing/sys-25-mcu-swd-port.png)
+
 - **供电**：设备需上电（PoE）——ST-LINK 不给板子供电，MCU 由设备电源供电；SWD 连上后 VREF 应读到约 3.2V。
 - **主机工具**：STM32CubeProgrammer（见 [§1.2](#12-主机工具)），使用 CLI `STM32_Programmer_CLI`。
 - **固件**：`ne503_mcu.elf`（见 [§1.1 固件包](#11-固件包)）。

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/3-software-guide/2-system-flashing.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/3-software-guide/2-system-flashing.md
@@ -425,6 +425,9 @@ The interface board has a dedicated MCU (STM32G0B0RET6, Cortex-M0+) that manages
 ### 4.1 Prerequisites
 
 - **Hardware**: an ST-LINK debugger (V2/V3) connected to the interface board's SWD port (PA13/SWDIO, PA14/SWDCLK·BOOT0, NRST, GND, 3V3 VREF). Pinout in [AIPC Board Connection](../2-hardware-guide/2-aipc-board-connection.md).
+
+![ST-LINK (SWD debug port) location on the interface board](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/software-guide/system-flashing/sys-25-mcu-swd-port.png)
+
 - **Power**: the device must be powered (PoE) — ST-LINK does not power the board; the MCU is powered by the device supply. After SWD hookup, VREF should read ~3.2V.
 - **Host tool**: STM32CubeProgrammer (see [§1.2](#12-host-tools)); uses the `STM32_Programmer_CLI` tool.
 - **Firmware**: `ne503_mcu.elf` (see [§1.1 Firmware Package](#11-firmware-package)).


### PR DESCRIPTION
## Summary

Add an annotated photo of the NE503 interface board (CF66-01) to the MCU firmware flashing section, highlighting the SWD debug port where the ST-LINK debugger plugs in.

## Changes

- **§4.1 Prerequisites** of `2-system-flashing.md`: insert one image right after the *Hardware* bullet, showing the physical SWD port location on the interface board.
- Synced in both **zh-Hans** and **en**.
- Image uploaded to CDN: `sys-25-mcu-swd-port.png` (follows the existing `sys-NN` naming).

## Context

The MCU flashing step (§4) requires connecting an ST-LINK to the interface board's SWD port, but the doc previously had no visual showing where that port actually is on the board. This image (red-outlined port at the bottom-left of the CF66-01 board) closes that gap.

Note: ST-LINK connects to the **SWD debug port** (position 15 in the hardware guide), which is distinct from the UART1 debug serial port (position 16). The caption reflects this.

## Test plan

- [x] `yarn build` passes for both `en` and `zh-Hans` (no broken links/anchors).
- [x] CDN image returns HTTP 200.
- [x] CN/EN image position and caption are aligned.