### PR TITLE
Update hardware guide for NE503 core and interface boards

### DIFF
--- a/docs/6-neoeyes-ne503-series/2-hardware-guide/1-core-board-connection.md
+++ b/docs/6-neoeyes-ne503-series/2-hardware-guide/1-core-board-connection.md
@@ -6,9 +6,9 @@ tags: [NE503, 核心处理板, IO配置, Hailo15H]
 
 # Core Board
 
-![NE503 硬件设计框图](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/hardware-guide/specifications/hardware-block-diagram.png)
+核心处理板承载 Hailo15H SoC、NPU、内存、存储子系统，通过板对板连接器（Board-to-Board Connectors）与接口板互联，引出 SoC 原生高速接口和扩展引脚。本文档从 chip-level 视角描述核心板上的硬件资源及引脚定义。
 
-核心处理板承载 Hailo15H SoC、NPU、内存、存储子系统，通过板对板连接器向接口板暴露扩展接口。本文档从 chip-level 视角描述核心板上的硬件资源及引脚定义。
+<img src="https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/hardware-guide/core-board-connection/core-board-annotation.png" alt="NE503 核心处理板接口标注" style={{ width: '60%', height: 'auto' }} />
 
 ## 硬件资源概述
 
@@ -23,6 +23,8 @@ NE503 由以下物理模组组成：
 | 镜头模组 | AN41908A-VBA | AF 自动变焦与自动对焦镜头驱动 |
 
 核心板与接口板通过板对板连接器互联：核心板提供 SoC 原生引脚，接口板上的设备通过连接器挂接到这些引脚。
+
+[下载 NE503 硬件设计框图](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/hardware-guide/specifications/hardware-block-diagram.png)
 
 ## 功能总览
 

--- a/docs/6-neoeyes-ne503-series/2-hardware-guide/2-aipc-board-connection.md
+++ b/docs/6-neoeyes-ne503-series/2-hardware-guide/2-aipc-board-connection.md
@@ -6,7 +6,19 @@ tags: [NE503, 接口板, IO配置, STM32G0B0]
 
 # Interface Board
 
-接口板通过独立 MCU（STM32G0B0RET6）管理外部 IO、电源及外设控制，通过 UART0 与核心处理板通信。
+接口板通过独立 MCU（STM32G0B0RET6）管理外部 IO、电源及外设控制，通过 UART0 与核心处理板通信。其关键接口分布在两侧，外部端子引出 PoE、Wiegand、报警、音频等对外接线。下图为实物标注：
+
+<div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap', alignItems: 'stretch' }}>
+  <div style={{ flex: '1', minWidth: '200px' }}>
+    <img src="https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/hardware-guide/aipc-board-connection/interface-board-annotation-1.png" alt="NE503 接口板接口标注（侧一）" style={{ width: '100%', height: 'auto' }} />
+  </div>
+  <div style={{ flex: '1', minWidth: '200px' }}>
+    <img src="https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/hardware-guide/aipc-board-connection/interface-board-annotation-2.png" alt="NE503 接口板接口标注（侧二）" style={{ width: '100%', height: 'auto' }} />
+  </div>
+  <div style={{ flex: '1', minWidth: '200px' }}>
+    <img src="https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/hardware-guide/aipc-board-connection/terminal-block-annotation.png" alt="NE503 外部端子标注" style={{ width: '100%', height: 'auto' }} />
+  </div>
+</div>
 
 ## 功能总览
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/2-hardware-guide/1-core-board-connection.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/2-hardware-guide/1-core-board-connection.md
@@ -6,9 +6,9 @@ tags: [NE503, core processing board, IO configuration, Hailo15H]
 
 # Core Board
 
-![NE503 Hardware Block Diagram](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/hardware-guide/specifications/hardware-block-diagram.png)
+The core processing board hosts the Hailo15H SoC, NPU, memory, and storage subsystems. It connects to the interface board via Board-to-Board Connectors, exposing native SoC high-speed interfaces and expansion pins. This document describes the hardware resources and pin definitions from a chip-level perspective.
 
-The core processing board hosts the Hailo15H SoC, NPU, memory, and storage subsystems. It exposes expansion interfaces to the interface board via board-to-board connectors. This document describes the hardware resources and pin definitions from a chip-level perspective.
+<img src="https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/hardware-guide/core-board-connection/core-board-annotation.png" alt="NE503 Core Board Interface Annotation" style={{ width: '60%', height: 'auto' }} />
 
 ## Hardware Resource Overview
 
@@ -23,6 +23,8 @@ NE503 consists of the following physical modules:
 | Lens Module | AN41908A-VBA | AF auto-zoom and autofocus lens driver |
 
 The core board and interface board are interconnected via board-to-board connectors: the core board provides native SoC pins, and devices on the interface board are connected to these pins through the connectors.
+
+[Download NE503 Hardware Block Diagram](https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/hardware-guide/specifications/hardware-block-diagram.png)
 
 ## Interface Overview
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/2-hardware-guide/2-aipc-board-connection.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-neoeyes-ne503-series/2-hardware-guide/2-aipc-board-connection.md
@@ -6,7 +6,19 @@ tags: [NE503, interface board, IO configuration, STM32G0B0]
 
 # Interface Board
 
-The interface board uses an independent MCU (STM32G0B0RET6) to manage external IO, power, and peripheral control. It communicates with the core processing board via UART0.
+The interface board uses an independent MCU (STM32G0B0RET6) to manage external IO, power, and peripheral control, and communicates with the core processing board via UART0. Its key interfaces are distributed across two sides, with the external terminal block exposing PoE, Wiegand, alarm, and audio wiring. The annotated photos are shown below:
+
+<div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap', alignItems: 'stretch' }}>
+  <div style={{ flex: '1', minWidth: '200px' }}>
+    <img src="https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/hardware-guide/aipc-board-connection/interface-board-annotation-1.png" alt="NE503 Interface Board Annotation (Side 1)" style={{ width: '100%', height: 'auto' }} />
+  </div>
+  <div style={{ flex: '1', minWidth: '200px' }}>
+    <img src="https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/hardware-guide/aipc-board-connection/interface-board-annotation-2.png" alt="NE503 Interface Board Annotation (Side 2)" style={{ width: '100%', height: 'auto' }} />
+  </div>
+  <div style={{ flex: '1', minWidth: '200px' }}>
+    <img src="https://resources.camthink.ai/wiki/img/neoeyes-ne503-series/hardware-guide/aipc-board-connection/terminal-block-annotation.png" alt="NE503 External Terminal Block Annotation" style={{ width: '100%', height: 'auto' }} />
+  </div>
+</div>
 
 ## Interface Overview
 


### PR DESCRIPTION
Revise the hardware guide to include new images and descriptions for the NE503 core and interface boards, enhancing clarity and detail for users.