### PR TITLE
feat(analytics): migrate tracker from Umami to CamthinkTracker

### DIFF
--- a/src/analytics/track.js
+++ b/src/analytics/track.js
@@ -1,21 +1,32 @@
-// Umami event tracking with pre-load queue.
-// window.umami isn't available until the async script finishes loading.
-// Events fired before then (e.g., 404_view on direct entry) are queued
-// and flushed by injectUmami()'s s.onload callback (see Root.js).
+// CamthinkTracker event tracking with pre-init queue.
+// SDK 脚本异步加载，init 之前调用 track() 会抛 "init must be called first"。
+// init 之前触发的事件（如首屏 page_not_found）先入队，
+// 由 Root.js 的 injectTracker() 在脚本 onload → init() 之后调 flushQueue 清空。
 let queue = [];
+let initialized = false; // SDK 是否已 init（init 之后才允许直发）
 
 export function flushQueue() {
-  if (typeof window === 'undefined' || !window.umami) return;
-  queue.forEach(({ eventName, props }) => {
-    window.umami.track(eventName, props);
-  });
+  if (typeof window === 'undefined' || !window.CamthinkTracker) return;
+  initialized = true; // 切换到直发模式
+  const pending = queue;
   queue = [];
+  pending.forEach(({ eventName, props }) => {
+    try {
+      window.CamthinkTracker.track(eventName, props);
+    } catch (e) {
+      // 非法事件名（违反 snake_case）/ SDK 异常 —— 静默丢弃，绝不炸页面
+    }
+  });
 }
 
 export function track(eventName, props) {
   if (typeof window === 'undefined') return;
-  if (window.umami) {
-    window.umami.track(eventName, props);
+  if (initialized && window.CamthinkTracker) {
+    try {
+      window.CamthinkTracker.track(eventName, props);
+    } catch (e) {
+      // 同上：静默丢弃，保页面渲染
+    }
   } else {
     queue.push({ eventName, props });
   }

--- a/src/theme/NotFound.js
+++ b/src/theme/NotFound.js
@@ -1,5 +1,6 @@
-// B4 404_view：访问不存在页面时上报。主题 shadowing（手动创建，未跑 swizzle）。
+// B4 page_not_found：访问不存在页面时上报。主题 shadowing（手动创建，未跑 swizzle）。
 // 关键：必须 wrap @theme-original/NotFound —— 原 NotFound 承载 404 页面 UI，不能丢。
+// 事件名须字母开头 snake_case（CamthinkTracker 校验），原 404_view 会 throw。
 import React from 'react';
 import NotFound from '@theme-original/NotFound';
 import { track } from '../analytics/track';
@@ -7,7 +8,7 @@ import { track } from '../analytics/track';
 export default function NotFoundWrapper(props) {
   React.useEffect(() => {
     if (process.env.NODE_ENV === 'production' && typeof window !== 'undefined') {
-      track('404_view', {
+      track('page_not_found', {
         path: window.location.pathname,
         referrer: document.referrer,
       });

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -3,32 +3,43 @@ import { useLocation } from '@docusaurus/router';
 import { hasConsent } from '../analytics/consent';
 import { track, flushQueue } from '../analytics/track';
 
-const UMAMI_SCRIPT_URL = 'https://wiki-data.camthink.ai/script.js';
-const UMAMI_WEBSITE_ID = '3ca6071b-afef-4f95-b095-88ef20bfb2a6';
+const TRACKER_SCRIPT_URL = 'https://analytics.camthink.ai/sdk/tracker.umd.js';
+const TRACKER_CONFIG = {
+  endpoint: 'https://analytics.camthink.ai/collect/v1/events',
+  project_key: 'pk_4fdf4e86fe5631cbf0a54cda15008c8b',
+  auto_track: {
+    page_view: true,
+    element_click: true,
+  },
+};
 const isProd = process.env.NODE_ENV === 'production';
 
 const KNOWN_LOCALES = ['zh-Hans', 'en'];
 
-// Umami 脚本动态注入（consent-gated，仅 production）。
-// 脚本加载后自动追踪 pageview（含 SPA 路由变化），无需手动 capture。
-function injectUmami() {
+// CamthinkTracker SDK 动态注入（consent-gated，仅 production）。
+// SDK 的 page_view 只在 init() 触发一次，不 hook history ——
+// SPA 路由切换的 page_view 由下方 location effect 手动补（CamthinkTracker.page()）。
+function injectTracker() {
   if (typeof document === 'undefined') return;
-  if (document.querySelector('script[data-umami]')) return;
+  if (document.querySelector('script[data-camthink-tracker]')) return;
   const s = document.createElement('script');
   s.async = true;
   s.defer = true;
-  s.src = UMAMI_SCRIPT_URL;
-  s.setAttribute('data-website-id', UMAMI_WEBSITE_ID);
-  s.setAttribute('data-umami', '');
-  s.onload = flushQueue;
+  s.src = TRACKER_SCRIPT_URL;
+  s.setAttribute('data-camthink-tracker', '');
+  s.onload = () => {
+    if (!window.CamthinkTracker) return;
+    window.CamthinkTracker.init(TRACKER_CONFIG); // 幂等：内部 f || ... guard
+    flushQueue(); // init 完成后清空缓冲事件，切换到直发模式
+  };
   document.head.appendChild(s);
 }
 
 if (isProd && typeof window !== 'undefined') {
-  if (hasConsent()) injectUmami();
+  if (hasConsent()) injectTracker();
   // consent 变化时注入（横幅未来接入点）
   window.addEventListener('consent-change', () => {
-    if (hasConsent()) injectUmami();
+    if (hasConsent()) injectTracker();
   });
 }
 
@@ -50,7 +61,7 @@ export default function Root({ children }) {
         return;
       }
       // 排除站点自身域名及采集域名
-      if (url.hostname === window.location.hostname || url.hostname === 'wiki-data.camthink.ai') return;
+      if (url.hostname === window.location.hostname || url.hostname === 'analytics.camthink.ai') return;
       // --- B4 download：外链子集（特定后缀），附加捕获（不 short-circuit，
       // 让 external_link_click 与 download 同时记录 —— 二者维度不同）。
       if (/\.(pdf|zip|bin|hex|tar\.gz|dmg|exe)$/i.test(url.pathname)) {
@@ -151,6 +162,17 @@ export default function Root({ children }) {
   // location 变化时重置 lastDepth（否则换页后不再报 25/50/75/100）。
   React.useEffect(() => {
     lastDepthRef.current = 0;
+  }, [location]);
+
+  // --- CamthinkTracker SPA page_view：SDK 只在 init() 报首次 page_view，
+  // 不 hook history，故路由切换需手动补。首屏若 SDK 未就绪则跳过（init 已报首次）。
+  React.useEffect(() => {
+    if (!isProd || typeof window === 'undefined') return;
+    try {
+      window.CamthinkTracker?.page?.();
+    } catch (e) {
+      // SDK 未 init —— 静默跳过（init 时已报首次 page_view）
+    }
   }, [location]);
 
   // --- B4 language_switch：locale 前缀变化检测。


### PR DESCRIPTION
- Root.js: inject CamthinkTracker SDK (onload -> init -> flushQueue), fix auto_track to object form, add SPA page_view via CamthinkTracker.page()
- track.js: switch to CamthinkTracker.track with pre-init queue and try/catch guard against invalid event names
- NotFound.js: rename 404_view -> page_not_found (SDK enforces snake_case)